### PR TITLE
line graph handle empty data

### DIFF
--- a/graphs/LineGraph/XScale/index.js
+++ b/graphs/LineGraph/XScale/index.js
@@ -50,6 +50,11 @@ module.exports = React.createClass({
   },
 
   renderScaleLines: function() {
+
+    if (this.props.series.length == 0) {
+      return;
+    }
+
     var props = this.props;
     var dataArray = props.series[0];
     var scaleLineGap = this.getWidth() / ( dataArray.length - 1 );

--- a/graphs/LineGraph/__tests__/index-test.js
+++ b/graphs/LineGraph/__tests__/index-test.js
@@ -8,23 +8,23 @@ describe('LineGraph', function() {
   var TestUtils = React.addons.TestUtils;
 
   var series = [
-        [
-          { date: new Date("2014, 1").toISOString(), value: 5 },
-          { date: new Date("2014, 2").toISOString(), value: 22 },
-          { date: new Date("2014, 3").toISOString(), value: 14 },
-          { date: new Date("2014, 4").toISOString(), value: 5 },
-          { date: new Date("2014, 5").toISOString(), value: 10 },
-          { date: new Date("2014, 6").toISOString(), value: 24 }
-        ],
-        [
-          { date: new Date("2014, 1").toISOString(), value: 4 },
-          { date: new Date("2014, 2").toISOString(), value: 6 },
-          { date: new Date("2014, 3").toISOString(), value: 11 },
-          { date: new Date("2014, 4").toISOString(), value: 2 },
-          { date: new Date("2014, 5").toISOString(), value: 4 },
-          { date: new Date("2014, 6").toISOString(), value: 23 }
-        ]
-      ];
+    [
+      { date: new Date("2014, 1").toISOString(), value: 5 },
+      { date: new Date("2014, 2").toISOString(), value: 22 },
+      { date: new Date("2014, 3").toISOString(), value: 14 },
+      { date: new Date("2014, 4").toISOString(), value: 5 },
+      { date: new Date("2014, 5").toISOString(), value: 10 },
+      { date: new Date("2014, 6").toISOString(), value: 24 }
+    ],
+    [
+      { date: new Date("2014, 1").toISOString(), value: 4 },
+      { date: new Date("2014, 2").toISOString(), value: 6 },
+      { date: new Date("2014, 3").toISOString(), value: 11 },
+      { date: new Date("2014, 4").toISOString(), value: 2 },
+      { date: new Date("2014, 5").toISOString(), value: 4 },
+      { date: new Date("2014, 6").toISOString(), value: 23 }
+    ]
+  ];
 
   describe('default', function() {
     var component;

--- a/graphs/LineGraph/__tests__/index-test.js
+++ b/graphs/LineGraph/__tests__/index-test.js
@@ -58,6 +58,22 @@ describe('LineGraph', function() {
     });
   });
 
+  describe('empty data', function() {
+    var component;
+
+    beforeEach(function() {
+      component = TestUtils.renderIntoDocument(<LineGraph series={ [] } seriesValueKey={'value'} />);
+      component.setState({
+        width: 200,
+        height: 200
+      });
+    });
+
+    it('should render LineGraph', function() {
+      expect(component).not.toBeNull();
+    });
+  });
+
   describe('stacked', function() {
     var component;
 


### PR DESCRIPTION
this component errors when the series contains no data. unfortunately this is the most common case for beneficiaries which have not published any events to rouse.