### PR TITLE
clickable fileinput with no pleaceholder

### DIFF
--- a/forms/FileInput/style.scss
+++ b/forms/FileInput/style.scss
@@ -13,11 +13,12 @@
 
 .hui-FileInput__input {
   color: $hui-input-text;
-  display: inline-block;
+  display: block;
   line-height: $hui-x-9;
   overflow: hidden;
   white-space: nowrap;
   width: 100%;
+  height: 100%;
 
   .hui-FileInput_hasFile & {
     color: inherit;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HUI",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "EDH UI library to share layout and base components between applications.",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
previously you could only click the 'browse' unless there was a placeholder or file selected.