### PR TITLE
Amatic Font With HTTPS

### DIFF
--- a/common.scss
+++ b/common.scss
@@ -6,4 +6,3 @@
 @import "sass/modules/links";
 @import "sass/modules/resets";
 @import "sass/mixins";
-@import url(//fonts.googleapis.com/css?family=Amatic+SC);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hui",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "description": "EDH UI library to share layout and base components between applications.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
explicitly loading Amatic font with HTTPS since protocol agnostic loading somehow does not laod it with https on https pages