### PR TITLE
Prefix loading indicator animations with hui

### DIFF
--- a/atoms/LoadingProgress/style.scss
+++ b/atoms/LoadingProgress/style.scss
@@ -12,16 +12,16 @@
 
 .hui-LoadingProgress__bar {
   width: 0%;
-  animation: complete 1000ms ease;
+  animation: hui-complete 1000ms ease;
 }
 
 .hui-LoadingProgress__bar--inProgress {
-  animation: progress 10000ms cubic-bezier(0.015, 0.780, 0.100, 1.005);
+  animation: hui-progress 10000ms cubic-bezier(0.015, 0.780, 0.100, 1.005);
   width: 90%;
   height: $x-1;
 }
 
-@keyframes progress {
+@keyframes hui-progress {
   0% {
     height: $x-1;
     width: 0%;
@@ -36,7 +36,7 @@
   }
 }
 
-@keyframes complete {
+@keyframes hui-complete {
   0% {
     height: $x-1;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hui",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "EDH UI library to share layout and base components between applications.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
This is to avoid collisions with other animations already in supporter.