### PR TITLE
TextInput Icons Click

### DIFF
--- a/DemoPage/examples/TextInput/index.js
+++ b/DemoPage/examples/TextInput/index.js
@@ -75,7 +75,8 @@ module.exports = React.createClass({
         icon="rocket"
         onChange={ change('demo_input_05') } />
       <TextInput
-        id="demo_input_icon"
+        id="demo_input_icon_left"
+        name="demo_input_icon_left"
         value={ this.state.form.demo_input_06 }
         label="custom icon left postion"
         icon="search"

--- a/forms/TextInput/style.scss
+++ b/forms/TextInput/style.scss
@@ -68,6 +68,7 @@
 .hui-TextInput__icon--left {
   left: $x-2;
   margin-top: -6px;
+  right: initial;
 }
 
 .hui-TextInput--valid .hui-TextInput__icon {

--- a/mixins/textInputProps.js
+++ b/mixins/textInputProps.js
@@ -62,7 +62,6 @@ export default {
   },
   defaults: {
     id: '',
-    name: '',
     type: 'text',
     value: '',
     label: 'Input',


### PR DESCRIPTION
Default prop `name:''` broke the labels of the inputs.
Also changes css of left-side icons to not cover entire input