### PR TITLE
Update colours

### DIFF
--- a/forms/DateInput/DatePickerDay/style.scss
+++ b/forms/DateInput/DatePickerDay/style.scss
@@ -22,6 +22,6 @@
   color: white;
 
   &:hover {
-    color: $green-lighter;
+    color: $green-light;
   }
 }

--- a/forms/DateInput/DatePickerPeriod/style.scss
+++ b/forms/DateInput/DatePickerPeriod/style.scss
@@ -10,6 +10,6 @@
   color: white;
 
   &:hover {
-    color: $green-lighter;
+    color: $green-light;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hui",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "EDH UI library to share layout and base components between applications.",
   "main": "index.js",
   "files": [

--- a/sass/_colors.scss
+++ b/sass/_colors.scss
@@ -1,8 +1,7 @@
 // everydayhero brand colours
 $green-active: #2bb65a;
-$green-lighter: #89C480;
-$green-light: #89C480;
-$green: #2E9C53;
+$green-light: #7ec775;
+$green: #01a044;
 $green-dark: #0A5E0D;
 
 $white: #FFFFFF;


### PR DESCRIPTION
See colours here: https://github.com/everydayhero/brand-guidelines/wiki/Colours

![screen shot 2015-11-27 at 11 22 43 am](https://cloud.githubusercontent.com/assets/859298/11433157/1aa0fa64-9505-11e5-8643-f9c8453bff49.png)
Example of `$green-light` on the arrow.


![screen shot 2015-11-27 at 11 16 22 am](https://cloud.githubusercontent.com/assets/859298/11433158/1acb06e2-9505-11e5-9be1-3c9a56c658a9.png)
Example of `$green` (the button) – `$green-dark` is also there with the underline on the nav.

I removed the `$green-lighter` variable and replaced the instances where it was used since it's a duplicate.