### PR TITLE
Refactor FilterSelect to make focus management easier

### DIFF
--- a/forms/Filter/index.js
+++ b/forms/Filter/index.js
@@ -34,12 +34,13 @@ export default React.createClass({
     }
   },
 
-  blur () {
-    this.refs.filterInput.blur()
+  componentDidMount () {
+    if (this.props.focused === true) {
+      this.refs.filterInput.refs.input.getDOMNode().focus()
+    }
   },
 
   filter (filterValue) {
-
     const query   = new RegExp(filterValue.split('').join('.*'), 'gi')
     const results = this.props.collection.filter((option) => {
       return this.props.properties.some((property) => {

--- a/forms/FilterSelect/DisplayWrap/index.js
+++ b/forms/FilterSelect/DisplayWrap/index.js
@@ -1,0 +1,67 @@
+import React from 'react'
+
+export default React.createClass({
+  displayName: 'DisplayWrap',
+
+  componentDidMount () {
+    if (this.props.focused) {
+      setTimeout(() => {
+        this.refs.input.getDOMNode().focus()
+      })
+    }
+  },
+
+  render () {
+    const {
+      options,
+      id,
+      label,
+      name,
+      selected,
+      Display,
+      displayProperty,
+      valueKey,
+      labelKey,
+      onFocus,
+      onBlur,
+      onChange,
+      onKeyDown,
+      onMouseDown,
+      onClick
+    } = this.props
+
+    return (
+      <div className="hui-FilterSelect__display">
+        <Display
+          label={ label }
+          selected={ selected }
+          displayProperty={ displayProperty } />
+
+        <select
+          id={ id }
+          ref="input"
+          name={ name }
+          value={ !!selected && selected[valueKey] }
+          className="hui-FilterSelect__display-input"
+          onFocus={ onFocus }
+          onBlur={ onBlur }
+          onChange={ onChange }
+          onKeyDown={ onKeyDown }
+          onMouseDown={ onMouseDown }
+          onClick={ onClick }>
+
+          { options.map((option) => {
+            return (
+              <option
+                key={ option.value }
+                value={ option[valueKey] }
+                label={ option[labelKey] }>
+                { option[labelKey] }
+              </option>
+            )
+          }) }
+        </select>
+      </div>
+    )
+  }
+})

--- a/forms/FilterSelect/__tests__/FilterSelectInput-test.js
+++ b/forms/FilterSelect/__tests__/FilterSelectInput-test.js
@@ -16,7 +16,7 @@ describe('FilterSelect', () => {
       expect(subject).to.eql(options)
     })
 
-    it('renders a TextInput for displaying the selected option', () => {
+    it('renders a Select for displaying the selected option', () => {
       let subject = renderIntoDocument(
         <FilterSelect options={ [] } />
       ).refs.displayInput
@@ -85,7 +85,7 @@ describe('FilterSelect', () => {
       let element = renderIntoDocument(
         <FilterSelect options={ [] } />
       )
-      let input = element.refs.displayInput.getDOMNode()
+      let input = element.refs.displayInput.refs.input.getDOMNode()
       Simulate.focus(input)
       let subject = element.state.focused
 
@@ -96,7 +96,7 @@ describe('FilterSelect', () => {
       let element = renderIntoDocument(
         <FilterSelect options={ [] } />
       )
-      let input = element.refs.displayInput.getDOMNode()
+      let input = element.refs.displayInput.refs.input.getDOMNode()
       Simulate.click(input)
       let subject = element.state.isOpen
 
@@ -109,7 +109,7 @@ describe('FilterSelect', () => {
           let element = renderIntoDocument(
             <FilterSelect options={ [] } />
           )
-          let input = element.refs.displayInput.getDOMNode()
+          let input = element.refs.displayInput.refs.input.getDOMNode()
           Simulate.focus(input)
           Simulate.keyDown(input, { keyCode: 40 })
 

--- a/forms/FilterSelect/index.js
+++ b/forms/FilterSelect/index.js
@@ -8,6 +8,7 @@ import inputMessage from '../../mixins/inputMessage'
 import FocusAggregate from '../FocusAggregate'
 import FilterSelectDisplay from './Display'
 import OptionList from '../OptionList'
+import DisplayWrap from './DisplayWrap'
 import Filter from '../Filter'
 import classnames from 'classnames'
 
@@ -119,7 +120,6 @@ export default React.createClass({
     this.setState({
       focused: true
     }, () => {
-      this.openOptionList()
       this.props.onFocus()
     })
   },
@@ -137,12 +137,12 @@ export default React.createClass({
   handleSelection (option) {
     const { labelKey, valueKey } = this.props
     this.setState({
-      isOpen: false,
+      focused: true,
       selectedOption: option,
       filterValue: option[labelKey],
       value: option[valueKey] && option[valueKey].toString()
     }, () => {
-      this.refs.displayInput.getDOMNode().focus()
+      this.closeOptionList()
       this.props.onChange(option[valueKey])
       this.props.onSelection(option)
       this.validate()
@@ -168,10 +168,8 @@ export default React.createClass({
     },
     40(e) {
       let optionList = this.refs.optionList
-      let filter = this.refs.filter
+      e.preventDefault()
       if (optionList) {
-        e.preventDefault()
-        filter.blur()
         optionList.focus()
       }
     }
@@ -201,12 +199,28 @@ export default React.createClass({
 
   handleDisplayClick (e) {
     e.preventDefault()
-    this.openOptionList()
+    this.setState({
+      focused: true
+    }, () => {
+      this.openOptionList()
+    })
+  },
+
+  handleDisplayFocus () {
+    this.setState({
+      focused: true
+    })
+  },
+
+  handleDisplayBlur () {
+    this.setState({
+      focused: false
+    })
   },
 
   renderDisplay () {
-    const selected = this.state.selectedOption
     const {
+      options,
       id,
       label,
       name,
@@ -214,44 +228,29 @@ export default React.createClass({
       valueKey,
       labelKey
     } = this.props
+    const {
+      focused,
+      selectedOption: selected
+    } = this.state
 
     return (
-      <div className="hui-FilterSelect__display">
-        <Display
-          label={ label }
-          selected={ selected }
-          displayProperty={ this.props.displayProperty }/>
-
-        <select
-          id={ id }
-          ref="displayInput"
-          name={ name }
-          value={ !!selected && selected[valueKey] }
-          className="hui-FilterSelect__display-input"
-          onChange={ this.handleDisplayChange }
-          onFocus={ (e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            this.setState({
-              focused: true
-            })
-          } }
-          onKeyDown={ this.handleDisplayKeyDown }
-          onMouseDown={ this.handleDisplayClick }
-          onClick={ this.handleDisplayClick }>
-
-          { this.props.options.map((option) => {
-            return (
-              <option
-                key={ option.value }
-                value={ option[valueKey] }
-                label={ option[labelKey] }>
-                { option[labelKey] }
-              </option>
-            )
-          }) }
-        </select>
-      </div>
+      <DisplayWrap
+        ref="displayInput"
+        options={ options }
+        id={ id }
+        label={ label }
+        name={ name }
+        Display={ Display }
+        valueKey={ valueKey }
+        labelKey={ labelKey }
+        focused={ focused }
+        selected={ selected }
+        onFocus={ this.handleDisplayFocus }
+        onBlur={ this.handleDisplayBlur }
+        onChange={ this.handleDisplayChange }
+        onKeyDown={ this.handleDisplayKeyDown }
+        onMouseDown={ this.handleDisplayClick }
+        onClick={ this.handleDisplayClick } />
     )
   },
 
@@ -276,11 +275,11 @@ export default React.createClass({
         <Filter
           ref="filter"
           inputOptions={{
-            autoFocus: true,
             spacing: 'compact',
             className: 'hui-FilterSelect__filter-input',
             onKeyDown: this.handleFilterKeyDown
           }}
+          focused
           filterValue={ filterValue }
           properties={ properties }
           collection={ options }

--- a/forms/FocusAggregate/index.js
+++ b/forms/FocusAggregate/index.js
@@ -12,6 +12,9 @@ export default React.createClass({
       onBlur: () => {},
     }
   },
+  componentWillUnmount() {
+    clearTimeout(blurringTimer)
+  },
   handleFocus (e) {
     clearTimeout(blurringTimer)
     this.props.onFocus(e)
@@ -20,7 +23,7 @@ export default React.createClass({
     clearTimeout(blurringTimer)
     blurringTimer = setTimeout(() => {
       this.props.onBlur(e)
-    }, 100)
+    })
   },
   render () {
     const { children, className } = this.props

--- a/forms/OptionList/DefaultDisplay/index.js
+++ b/forms/OptionList/DefaultDisplay/index.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 import React from 'react'
 import classnames from 'classnames'

--- a/forms/OptionList/Item/index.js
+++ b/forms/OptionList/Item/index.js
@@ -15,7 +15,7 @@ export default React.createClass({
     shouldScroll: React.PropTypes.bool,
     valueKey: React.PropTypes.string,
     labelKey: React.PropTypes.string,
-    onChange: React.PropTypes.func,
+    onSelection: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,
     onKeyDown: React.PropTypes.func,
     setScroll: React.PropTypes.func
@@ -31,7 +31,7 @@ export default React.createClass({
       shouldScroll: false,
       valueKey: 'value',
       labelKey: 'label',
-      onChange: () => {},
+      onSelection: () => {},
       onMouseOver: () => {},
       onKeyDown: () => {},
       setScroll: () => {}
@@ -69,34 +69,25 @@ export default React.createClass({
     let { shouldFocus, isCandidate, shouldScroll } = this.props
 
     if (shouldFocus) {
-      this.focus()
+      this.refs.radio.getDOMNode().focus()
     } else if (!shouldFocus && shouldScroll && isCandidate) {
       let scrollPos = this.getDOMNode().offsetTop - 20
       this.props.setScroll(scrollPos)
     }
   },
 
-  focus () {
-    this.refs.radio.getDOMNode().focus()
-  },
-
-  handleChange (e) {
-    let { onChange, option } = this.props
-
-    if (e.target.checked) {
-      onChange(option)
-    }
+  handleSelection () {
+    let { onSelection, option } = this.props
+    onSelection(option)
   },
 
   handleMouseOver () {
     let { onMouseOver, option } = this.props
-
     onMouseOver(option)
   },
 
   handleKeyDown (e) {
     let { onKeyDown } = this.props
-
     onKeyDown(e)
   },
 
@@ -116,18 +107,20 @@ export default React.createClass({
         key={ option[valueKey] }
         className="hui-OptionListItem">
         <input
-          autoFocus={ this.props.shouldFocus }
           type="radio"
           ref="radio"
           id={ `option-list-item-${option[valueKey]}` }
+          name={ `option-list-item-${option[valueKey]}` }
           className="hui-OptionListItem__radio--hidden"
           value={ option[valueKey] }
           checked={ isSelected }
           onKeyDown={ this.handleKeyDown }
-          onChange={ this.handleChange }
-          name="selected-option" />
+          readOnly />
 
         <label
+          ref="label"
+          onMouseDown={ this.handleSelection }
+          onTouchStart={ this.handleSelection }
           onMouseOver={ this.handleMouseOver }
           className="hui-OptionListItem__radio-label"
           htmlFor={ `option-list-item-${option[valueKey]}` }>

--- a/forms/OptionList/__tests__/OptionList-test.js
+++ b/forms/OptionList/__tests__/OptionList-test.js
@@ -177,15 +177,9 @@ describe('OptionList', () => {
       ]
       let element = renderIntoDocument(<OptionList options={ options } />)
       let item    = element.refs['option-list-item-1']
-      let radio   = item.refs.radio
+      let label   = item.refs.label
 
-      let mockEvent = {
-        target: {
-          checked: true
-        }
-      }
-
-      Simulate.change(radio.getDOMNode(), mockEvent)
+      Simulate.mouseDown(label.getDOMNode())
       expect(element.state.selected).to.eql(options[1])
       expect(element.state.shouldScroll).to.eql(false)
     })

--- a/forms/OptionList/index.js
+++ b/forms/OptionList/index.js
@@ -161,7 +161,7 @@ export default React.createClass({
     return !!highlightedValue && (option[highlightedKey] === highlightedValue)
   },
 
-  handleOptionChange(option) {
+  handleOptionSelection(option) {
     this.setSelected(option)
   },
 
@@ -202,7 +202,7 @@ export default React.createClass({
           isHighlighted={ this.isHighlighted(option) }
           isCandidate={ isCandidate }
           isSelected={ this.isSelected(option) }
-          onChange={ this.handleOptionChange }
+          onSelection={ this.handleOptionSelection }
           onMouseOver={ this.handleOptionMouseOver }
           onKeyDown={ this.handleOptionKeyDown }
           setScroll={ this.setScroll } />


### PR DESCRIPTION
Having a component for DisplayWrap and OptionList means that when they
mount they can focus

Removes the timeout for Focus aggregate, should smooth out differences
mahcine to machine