### PR TITLE
Add CopyInput component, related to [TA-8433]

### DIFF
--- a/DemoPage/examples/CopyInput/index.js
+++ b/DemoPage/examples/CopyInput/index.js
@@ -1,0 +1,17 @@
+'use strict'
+
+import React from 'react'
+import CopyInput from '../../../forms/CopyInput'
+
+export default React.createClass({
+  displayName: 'CopyInputExample',
+
+  render() {
+    return (
+      <div>
+        <h3 className="DemoPage__h3" id="CopyInput">CopyInput</h3>
+        <CopyInput value="http://everydayhero.com/" />
+      </div>
+    )
+  }
+})

--- a/DemoPage/index.js
+++ b/DemoPage/index.js
@@ -9,6 +9,7 @@ import LineGraph from './examples/LineGraph'
 import Legend from './examples/Legend'
 import Visualisation from './examples/DataVisualisation'
 import TextInput from './examples/TextInput'
+import CopyInput from './examples/CopyInput'
 import ReadOnlyAddress from './examples/ReadOnlyAddress'
 import AddressInput from './examples/AddressInput'
 import AddressFieldset from './examples/AddressFieldset'
@@ -87,6 +88,7 @@ export default React.createClass({
           <h2 className="DemoPage__h2" id="forms">Forms</h2>
           <div className="DemoPage__group">
             <TextInput />
+            <CopyInput />
             <ReadOnlyAddress />
             <AddressInput />
             <AddressLookup />

--- a/assets.scss
+++ b/assets.scss
@@ -57,6 +57,7 @@
 @import "forms/TagList/Item/style";
 @import "forms/TextArea/style";
 @import "forms/TextInput/style";
+@import "forms/CopyInput/style";
 @import "forms/UrlInput/style";
 @import "forms/TextCountDownInput/style";
 @import "forms/Fieldset/style";

--- a/docs.md
+++ b/docs.md
@@ -345,6 +345,11 @@ A read-only text input that comes with a handy copy button. Note: In Safari a se
 #### PropTypes
 
 - `disabled` [Boolean] – Disable input (Default false)
+- `label` [String] – Text label that appears at the top of the input
+- `labelCopied` [String] – Text label that appears on the copy button after a copy action
+- `labelCopy` [String] – Text label that appears on the copy button
+- `labelSelect` [String] – Fallback text label for the copy button, displays for Safari/Mobile Safari
+- `copyError` [String] – An error message that displays if the copy action fails
 - `id` [String] - Custom id attribute (Optional)
 - `name` [String] - Field name (Optional)
 - `onBlur` [Function] – On Blur callback (Optional)

--- a/docs.md
+++ b/docs.md
@@ -338,6 +338,33 @@ Basic text input.
 
 TextInput [Demo](https://shared-scripts.s3.amazonaws.com/hui-{{ latest-version }}/index.html#TextInput)
 
+### CopyInput
+
+A read-only text input that comes with a handy copy button. Note: In Safari a select button is rendered instead, as Safari currently does not support JavaScript based clipboard API's.
+
+#### PropTypes
+
+- `disabled` [Boolean] – Disable input (Default false)
+- `id` [String] - Custom id attribute (Optional)
+- `name` [String] - Field name (Optional)
+- `onBlur` [Function] – On Blur callback (Optional)
+- `onKeyDown` [Function] – On Keydown callback (Optional)
+- `readOnly` [Boolean] – Set input to read only (Default true)
+- `spacing` [String one of "loose", "tight" or "compact"] – Layout options (Default loose)
+- `value` [String, Intiger, Float] – Value of input
+- `layout` [String one of "full", "wide", "half", "narrow" or "quarter"] – Defines input layout width (Default Full)
+
+```html
+<CopyInput
+  id='demo_input'
+  name="demo_name"
+  value='http://your-share-url-here.com/'
+  label='Your text label here' />
+```
+
+CopyInput [Demo](https://shared-scripts.s3.amazonaws.com/hui-{{ latest-version }}/index.html#CopyInput)
+
+
 ### ReadOnlyAddress
 
 Read only address input (Contactinates address values with ",").

--- a/forms/CopyInput/__tests__/CopyInput-test.js
+++ b/forms/CopyInput/__tests__/CopyInput-test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+import CopyInput from '../'
+
+describe('CopyInput', () => {
+  let element, input, button
+
+  beforeEach(() => {
+    element = renderIntoDocument(<CopyInput value="foobar" name="underTest" id="baz" />)
+    input   = findByProp(element, 'name', 'underTest').getDOMNode()
+    button  = findByClass(element, 'hui-CopyInput__button').getDOMNode()
+  })
+
+  it('renders a text field with a given value', () => {
+    input.value.should.equal('foobar')
+  })
+
+  it('renders copy button', () => {
+    button.tagName.should.equal('BUTTON')
+  })
+
+  it('focuses the text input when the copy button is clicked', () => {
+    Simulate.click(button)
+    document.activeElement.should.equal(input)
+  })
+
+  it('renders a default text label on the copy button', () => {
+    button.textContent.should.contain('Copy')
+  })
+
+  it('renders a different text label on the copy button if text has been copied', () => {
+    element.setState({ copied: true })
+    button.textContent.should.contain('Copied')
+  })
+})

--- a/forms/CopyInput/__tests__/CopyInput-test.js
+++ b/forms/CopyInput/__tests__/CopyInput-test.js
@@ -32,4 +32,9 @@ describe('CopyInput', () => {
     element.setState({ copied: true })
     button.textContent.should.contain('Copied')
   })
+
+  it('shows an error message if a copy failed', () => {
+    element.setState({ errors: ['fail message'] })
+    element.getDOMNode().textContent.should.contain('fail message')
+  })
 })

--- a/forms/CopyInput/index.js
+++ b/forms/CopyInput/index.js
@@ -17,6 +17,7 @@ export default React.createClass({
     labelCopied: React.PropTypes.string,
     labelCopy: React.PropTypes.string,
     labelSelect: React.PropTypes.string,
+    copyError: React.PropTypes.string,
     layout: React.PropTypes.string,
     name: React.PropTypes.string,
     onBlur: React.PropTypes.func,
@@ -35,6 +36,7 @@ export default React.createClass({
       labelCopied: 'Copied',
       labelCopy: 'Copy',
       labelSelect: 'Select',
+      copyError: 'Copy command failed. Please try to copy manually instead.',
       layout: 'full',
       name: null,
       onBlur() {},
@@ -48,7 +50,10 @@ export default React.createClass({
   },
 
   getInitialState() {
-    return { copied: false }
+    return {
+      copied: false,
+      errors: []
+    }
   },
 
   handleFocus({ inputElement }) {
@@ -69,7 +74,7 @@ export default React.createClass({
         this.setState({ copied: false })
       }, 4000)
     } catch (error) {
-      console.warn('Copy command is not supported in this browser')
+      this.setState({ errors: [this.props.copyError] })
     }
   },
 
@@ -121,7 +126,8 @@ export default React.createClass({
               ref="copyInput"
               spacing="compact"
               layout="full"
-              onFocus={ this.handleFocus } />
+              onFocus={ this.handleFocus }
+              errors={ this.state.errors } />
           </div>
           { this.renderCopyButton() }
         </div>

--- a/forms/CopyInput/index.js
+++ b/forms/CopyInput/index.js
@@ -1,0 +1,131 @@
+'use strict'
+
+import React from 'react'
+import classnames from 'classnames'
+import bowser from 'bowser'
+import TextInput from '../TextInput'
+import Icon from '../../atoms/Icon'
+
+let copiedTimer
+
+export default React.createClass({
+  displayName: 'CopyInput',
+  propTypes: {
+    className: React.PropTypes.string,
+    disabled: React.PropTypes.bool,
+    label: React.PropTypes.string,
+    labelCopied: React.PropTypes.string,
+    labelCopy: React.PropTypes.string,
+    labelSelect: React.PropTypes.string,
+    layout: React.PropTypes.string,
+    name: React.PropTypes.string,
+    onBlur: React.PropTypes.func,
+    onKeyDown: React.PropTypes.func,
+    onTab: React.PropTypes.func,
+    spacing: React.PropTypes.string,
+    value: React.PropTypes.string
+  },
+
+  getDefaultProps() {
+    return {
+      disabled: false,
+      icon: null,
+      id: null,
+      label: 'Copy this value',
+      labelCopied: 'Copied',
+      labelCopy: 'Copy',
+      labelSelect: 'Select',
+      layout: 'full',
+      name: null,
+      onBlur() {},
+      onKeyDown() {},
+      onTab() {},
+      readOnly: true,
+      spacing: 'loose',
+      type: 'text',
+      value: ''
+    }
+  },
+
+  getInitialState() {
+    return { copied: false }
+  },
+
+  handleFocus({ inputElement }) {
+    if (inputElement && inputElement.setSelectionRange) {
+      inputElement.setSelectionRange(0, inputElement.value.length)
+    }
+  },
+
+  selectAndCopy() {
+    this.refs.copyInput.focus()
+
+    try {
+      document.execCommand('copy')
+      this.setState({ copied: true })
+
+      clearTimeout(copiedTimer)
+      copiedTimer = setTimeout(() => {
+        this.setState({ copied: false })
+      }, 4000)
+    } catch (error) {
+      console.warn('Copy command is not supported in this browser')
+    }
+  },
+
+  renderCopyButton() {
+    const { labelCopy, labelCopied, labelSelect } = this.props
+    const selectBlock = <span>{ labelSelect }</span>
+    const copyBlock   = <span><Icon icon="clipboard" /> { labelCopy }</span>
+    const copiedBlock = <span><Icon icon="check" /> { labelCopied }</span>
+    let content
+
+    /**
+     * Sniffing for Safari since it doesn't support JS based
+     * clipboard API's, or a reliable way to feature detect them.
+     */
+    const supportsCopy = (!bowser.safari && !bowser.ios)
+
+    if (this.state.copied && supportsCopy) {
+      content = copiedBlock
+    } else if (supportsCopy) {
+      content = copyBlock
+    } else {
+      content = selectBlock
+    }
+
+    return (
+      <div className="hui-CopyInput__buttonWrapper">
+        <button className="hui-CopyInput__button" onClick={ this.selectAndCopy }>
+          { content }
+        </button>
+      </div>
+    )
+  },
+
+  render() {
+    const { className, layout, spacing } = this.props
+    const classes = classnames([
+      className,
+      'hui-CopyInput--' + layout,
+      'hui-CopyInput--' + spacing,
+      'hui-CopyInput'
+    ])
+
+    return (
+      <div className={ classes }>
+        <div className="hui-CopyInput__wrapper">
+          <div className="hui-CopyInput__input">
+            <TextInput
+              { ...this.props }
+              ref="copyInput"
+              spacing="compact"
+              layout="full"
+              onFocus={ this.handleFocus } />
+          </div>
+          { this.renderCopyButton() }
+        </div>
+      </div>
+    )
+  }
+})

--- a/forms/CopyInput/style.scss
+++ b/forms/CopyInput/style.scss
@@ -1,0 +1,68 @@
+@import "../TextInput/style";
+
+.hui-CopyInput {
+  float: left;
+
+  .hui-TextInput__label {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+.hui-CopyInput__wrapper {
+  width: 100%;
+  display: table;
+
+  .hui-IconWrapper {
+    padding-right: $x-1;
+  }
+}
+
+.hui-CopyInput__input {
+  width: 100%;
+}
+
+.hui-CopyInput__input, .hui-CopyInput__buttonWrapper {
+  display: table-cell;
+  vertical-align: top;
+}
+
+.hui-CopyInput__button {
+  @extend %general-reset;
+  @extend %a-reset;
+  transition: all 160ms ease-out;
+  display: inline-block;
+  overflow: hidden;
+  line-height: $x-9;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  outline-color: transparent;
+  outline-style: none;
+  vertical-align: middle;
+  background-color: transparent;
+  font-size: 14px;
+  padding: 0 $x-4;
+  width: 100px;
+  height: 42px;
+  position: relative;
+  color: white;
+  background-color: $green;
+  border-top-right-radius: $border-radius;
+  border-bottom-right-radius: $border-radius;
+
+  &:hover, &:focus {
+    color: white;
+    background-color: $green-active;
+    border-color: $green-active;
+  }
+
+  &:active {
+    color: white;
+    background-color: $green;
+  }
+}
+
+@include input-sizes(CopyInput);

--- a/forms/TextInput/__tests__/TextInput-test.js
+++ b/forms/TextInput/__tests__/TextInput-test.js
@@ -261,7 +261,8 @@ describe('TextInput', function() {
 
       var object = {
         element: element.getDOMNode(),
-        value: 'testValue'
+        value: 'testValue',
+        inputElement: input
       }
 
       onFocus.should.have.been.calledWith(object)

--- a/forms/TextInput/index.js
+++ b/forms/TextInput/index.js
@@ -27,6 +27,10 @@ export default React.createClass({
     }
   },
 
+  focus() {
+    this.refs.input.getDOMNode().focus()
+  },
+
   blur () {
     this.refs.input.getDOMNode().blur()
   },

--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -63,14 +63,19 @@ export default {
   },
 
   handleFocus() {
-    let props = this.props
-    if (props.disabled || props.readOnly) { return }
+    const { disabled, readOnly, onFocus, value } = this.props
 
-    this.setState({ focused: true })
-    if (props.onFocus) {
-      props.onFocus({
+    if (disabled) { return }
+
+    if (!readOnly) {
+      this.setState({ focused: true })
+    }
+
+    if (onFocus) {
+      onFocus({
         element: this.getDOMNode(),
-        value: props.value
+        value,
+        inputElement: this.refs.input.getDOMNode()
       })
     }
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel": "^5.8.23",
     "babelify": "^6.1.2",
     "bluebird": "^2.9.34",
+    "bowser": "^1.0.0",
     "classnames": "~1.2.0",
     "console-polyfill": "^0.2.2",
     "exenv": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hui",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "description": "EDH UI library to share layout and base components between applications.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
### Chrome/Firefox/IE behaviour:

![example2](https://cloud.githubusercontent.com/assets/859298/12742036/b692d45e-c9cd-11e5-80f8-f87f35d13279.gif)

### Safari behaviour:

![example3](https://cloud.githubusercontent.com/assets/859298/12742035/b68ccfd2-c9cd-11e5-9c67-beed6abc8818.gif)

Note: JS based clipboard API's aren't supported in Safari (including mobile). As a fallback the button switches to say "select", where the user can quickly press command+C or tap to view the copy/paste menu in iOS.