### PR TITLE
Allow touch scrolling the option list

### DIFF
--- a/forms/OptionList/Item/index.js
+++ b/forms/OptionList/Item/index.js
@@ -78,7 +78,15 @@ export default React.createClass({
 
   handleSelection () {
     let { onSelection, option } = this.props
-    onSelection(option)
+    this.down && onSelection(option)
+  },
+
+  handleDown () {
+    this.down = true
+  },
+
+  handleMove () {
+    this.down = false
   },
 
   handleMouseOver () {
@@ -114,13 +122,15 @@ export default React.createClass({
           className="hui-OptionListItem__radio--hidden"
           value={ option[valueKey] }
           checked={ isSelected }
+          onBlur={ this.handleSelection }
           onKeyDown={ this.handleKeyDown }
           readOnly />
 
         <label
           ref="label"
-          onMouseDown={ this.handleSelection }
-          onTouchStart={ this.handleSelection }
+          onMouseDown={ this.handleDown }
+          onTouchStart={ this.handleDown }
+          onTouchMove={ this.handleMove }
           onMouseOver={ this.handleMouseOver }
           className="hui-OptionListItem__radio-label"
           htmlFor={ `option-list-item-${option[valueKey]}` }>

--- a/forms/OptionList/__tests__/OptionList-test.js
+++ b/forms/OptionList/__tests__/OptionList-test.js
@@ -178,8 +178,10 @@ describe('OptionList', () => {
       let element = renderIntoDocument(<OptionList options={ options } />)
       let item    = element.refs['option-list-item-1']
       let label   = item.refs.label
+      let radio   = item.refs.radio
 
       Simulate.mouseDown(label.getDOMNode())
+      Simulate.blur(radio.getDOMNode())
       expect(element.state.selected).to.eql(options[1])
       expect(element.state.shouldScroll).to.eql(false)
     })


### PR DESCRIPTION
We can't use click, as it fires after blur and we use blur to close the
options list in the filter select / country select / url search select

So here we use mousedown / touch start, touchstart fires when the user
tries to scroll. To get around that triggering a selection, we keep a
var which tells us whether or not the touch has moved, if it's moved
selection wasn't intended so don't select.