### PR TITLE
Use buildkite message instead of buildkite branch to trigger deploy

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,5 +18,6 @@ steps:
 
   - name: ":package: Deploy"
     command: "bin/buildkite bin/ci run bin/deploy"
+    branches: "master"
     agents:
       queue: native

--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 pat="^v?([0-9]|\.)+$"
-if [[ "${BUILDKITE_BRANCH}" =~ $pat ]]; then
+if [[ "${BUILDKITE_MESSAGE}" =~ $pat ]]; then
   # Deploy assets
   ./bin/version_check
   node_modules/.bin/gulp assets-build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ tests:
     - NPM_EMAIL
     - AWS_KEY
     - AWS_SECRET
-    - BUILDKITE_BRANCH
+    - BUILDKITE_MESSAGE


### PR DESCRIPTION
Turns out `BUILDKITE_BRANCH` was not what we thought it was when doing a bump it was always **master**, instead `BUILDKITE_MESSAGE` seems more appropriate.

From the build environment vars:

<img width="227" alt="screen shot 2016-04-08 at 5 53 04 pm" src="https://cloud.githubusercontent.com/assets/859298/14377405/c5c97a18-fdb2-11e5-9ef6-b249239210a2.png">

<img width="216" alt="screen shot 2016-04-08 at 5 55 12 pm" src="https://cloud.githubusercontent.com/assets/859298/14377470/124c54be-fdb3-11e5-8802-e815516f3128.png">
