### PR TITLE
Add name and value props to Button

### DIFF
--- a/buttons/Button/index.js
+++ b/buttons/Button/index.js
@@ -17,6 +17,8 @@ export default React.createClass({
     iconLeft: React.PropTypes.bool,
     iconSpin: React.PropTypes.bool,
     id: React.PropTypes.string,
+    name: React.PropTypes.string,
+    value: React.PropTypes.string,
     inverse: React.PropTypes.bool,
     borderless: React.PropTypes.bool,
     kind: React.PropTypes.oneOf([
@@ -101,6 +103,8 @@ export default React.createClass({
     return (
       <El { ...dataAttributesFromProps(props) } target={ props.target } className={ classes }
         id={ props.id }
+        name={ props.name }
+        value={ props.value }
         tabIndex={ 1 }
         type={ props.type }
         to={ href }


### PR DESCRIPTION
So, weird thing, you can use the value and name of the submit buttom
from a form to provide extra params. This is used in OPGS to send the
selected OAuth provider.

https://developer.mozilla.org/en/docs/Web/HTML/Element/button