### PR TITLE
Update browserify to fix sourcemap errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "babel-register": "^6.5.2",
     "babelify": "^7.2.0",
     "blanket": "^1.1.6",
-    "browserify": "^8.1.3",
+    "browserify": "^13.0.0",
     "browserify-incremental": "^3.0.1",
     "chai": "^3.0.0",
     "compression": "^1.3.0",


### PR DESCRIPTION
Updates `browserify` to avoid the following error when `debug: true` is set:

```
/Users/sam.enoka/Projects/hui/node_modules/browserify/node_modules/browser-pack/node_modules/combine-source-map/node_modules/inline-source-map/node_modules/source-map/lib/source-map/source-map-generator.js:275
        throw new Error('Invalid mapping: ' + JSON.stringify({
              ^
Error: Invalid mapping: {"generated":{"line":73,"column":0},"source":"index.js","original":{},"name":null}
```

### State

- [x] Ready for review
- [x] Ready for merge

### Pre-merge Tasks

Tasks to be actioned by the author of this pull request **BEFORE** it is merged.

- [ ] Merge #268

### Notes

Ported to `v-3` branch: #271