### PR TITLE
Remove broken SASS extends (v3)

### DIFF
--- a/sass/modules/_forms.scss
+++ b/sass/modules/_forms.scss
@@ -61,8 +61,6 @@
 }
 
 %hui-text-input--readOnly {
-  @extend %hui-text-input;
-
   background: none;
   border: none;
   cursor: default;
@@ -78,7 +76,6 @@
 }
 
 %hui-placeholder {
-  @extend %hui-text-input-label;
   padding: 0 $x-4;
   color: $grey-light;
 }
@@ -90,7 +87,6 @@
 
 %hui-text-area {
   @extend %hui-input-wrap;
-  @extend %hui-text-input;
   padding: $x-3;
   min-height: $x-36;
   font-family: "Lato", Helvetica, Arial, sans-serif;

--- a/search/AggregateSearchModal/style.scss
+++ b/search/AggregateSearchModal/style.scss
@@ -6,8 +6,6 @@
 }
 
 .AggregateSearchModal__header {
-  @extend %clearfix;
-
   width: 100%;
   padding: $x-4;
   position: relative;
@@ -90,7 +88,6 @@
 }
 
 .AggregateSearchModal__content {
-  @extend %clearfix;
   margin: {
     left: auto;
     right: auto;
@@ -105,7 +102,6 @@
 }
 
 .AggregateSearchModal__filters {
-  @extend %clearfix;
   position: absolute;
   top: 107px;
   left: $x-8;

--- a/search/AggregateSearchResult/style.scss
+++ b/search/AggregateSearchResult/style.scss
@@ -1,5 +1,4 @@
 .AggregateSearchResult {
-  @extend %clearfix;
   display: block;
   color: $grey-light;
   line-height: 1;


### PR DESCRIPTION
After a recent update `gulp-sass` has begun complaining (rightfully) about extends that point to nowhere. This PR fixes the error by pruning them all away.

Error example:

```
events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: sass/modules/_forms.scss
Error: "%hui-text-input--readOnly" failed to @extend "%hui-text-input".
       The selector "%hui-text-input" was not found.
       Use "@extend %hui-text-input !optional" if the extend should be able to fail.
        on line 64 of sass/modules/_forms.scss
>>   @extend %hui-text-input;
   --^
```

### State

- [x] Ready for review
- [x] Ready for merge