### PR TITLE
Transpile `urls.js`

### DIFF
--- a/gulp_tasks/transpile.js
+++ b/gulp_tasks/transpile.js
@@ -27,7 +27,8 @@ gulp.task("transpile-js", function () {
   return gulp.src([
       `${sourceMatcher}/**/*.js`,
       `!${sourceMatcher}/**/*-test.js`,
-      'api.js'
+      'api.js',
+      'urls.js'
     ])
     .pipe(babel())
     .pipe(gulp.dest(destination));


### PR DESCRIPTION
Fixes the `Footer` component which imports `url.js` from the root of the module.

See https://github.com/everydayhero/hui/blob/master/layout/Footer/index.js#L10