### PR TITLE
Use bindEvents lib for friendlier testing (version 3)

### DIFF
--- a/graphs/LineGraph/index.js
+++ b/graphs/LineGraph/index.js
@@ -7,8 +7,7 @@ import YScale              from './YScale'
 import XScale              from './XScale'
 import ToolTip             from './ToolTip'
 import LoadingPlaceholder  from './LoadingPlaceholder'
-import addEventListener    from '../../lib/addEventListener'
-import removeEventListener from '../../lib/removeEventListener'
+import { addListeners, removeListeners } from '../../lib/bindEvents'
 
 module.exports = React.createClass({
   displayName: 'LineGraph',
@@ -57,7 +56,7 @@ module.exports = React.createClass({
 
   componentDidMount: function() {
     this.handleResizeDebounce = _.debounce(this.handleResize, 300, { maxWait: 1000 })
-    addEventListener('resize', this.handleResizeDebounce)
+    addListeners('resize', this.handleResizeDebounce, window)
     this.handleResize()
   },
 
@@ -66,7 +65,7 @@ module.exports = React.createClass({
   },
 
   componentWillUnmount: function() {
-    removeEventListener('resize', this.handleResizeDebounce)
+    removeListeners('resize', this.handleResizeDebounce, window)
   },
 
   transformCollection: function() {


### PR DESCRIPTION
Playing with some tests in NFP and noticed that this component started barking pretty loudly. Looks like jsdom has `window` defined but not `addEventListener` or `attachEvent` which leads to... issues.

### State

- [x] Ready for review
- [x] Ready for merge

### Notes

Related PR for `master`: https://github.com/everydayhero/hui/pull/293