### PR TITLE
requireValue in URLSearchSelectInput was overwriting state.isOpen

### DIFF
--- a/forms/UrlSearchSelect/__tests__/URLSearchSelectInput-test.js
+++ b/forms/UrlSearchSelect/__tests__/URLSearchSelectInput-test.js
@@ -121,6 +121,34 @@ describe('UrlSearchSelect', () => {
         expect(element.state.hasError).to.eq(true)
         expect(onError).calledWith(true)
       })
+
+      it('ensures state.isOpen is true (to display error)', () => {
+        let element = renderIntoDocument(
+          <UrlSearchSelect
+            required
+            url="http://everydayhero.com" />
+        )
+        element.setState({isOpen: false})
+        element.requireValue()
+        expect(element.state.isOpen).to.eq(true)
+      })
+    })
+
+    context('otherwise', () => {
+      it('does not mutate state.isOpen', () => {
+        let element = renderIntoDocument(
+          <UrlSearchSelect
+            url="http://everydayhero.com" />
+        )
+
+        element.setState({isOpen: false})
+        element.requireValue()
+        expect(element.state.isOpen).to.eq(false)
+
+        element.setState({isOpen: true})
+        element.requireValue()
+        expect(element.state.isOpen).to.eq(true)
+      })
     })
   })
 

--- a/forms/UrlSearchSelect/index.js
+++ b/forms/UrlSearchSelect/index.js
@@ -193,11 +193,11 @@ export default React.createClass({
 
   requireValue() {
     let { required } = this.props
-    let { selectedOption } = this.state
+    let { selectedOption, isOpen } = this.state
     let hasError = !!required && !selectedOption
     this.setState({
       hasError,
-      isOpen: hasError
+      isOpen: hasError ? true : isOpen
     }, () => {
       this.props.onError(hasError)
     })


### PR DESCRIPTION
This is related to the bug where the AddressSearchInput was auto-hiding when you mouse over the results. Basically, the URLSearchInput was setting the 'isOpen' state variable to whatever the 'hasError' state was on hover. If there was no error in the state, isOpen was set to false which closed the dropdown.

Expected behaviour was that if error was *true* isOpen should always be true, so I've amended the code and added specs to cover that.

### State

- [x] Ready for review

### Pre-merge Tasks

Tasks to be actioned by the author of this pull request **BEFORE** it is merged.

- [x] Fix bug
- [ ] Bump version in package.json

### Post-merge Tasks

Tasks to be actioned by the author of this pull request **AFTER** it is merged.

- [ ] npm publish

### Testing Notes

Regression tests to cover the behaviour are in the pull request, however the steps to reproduce the bug prior to this fix are as below:

1. Run `supporter` locally from `master`. (Make sure you have one_page turned on)
2. Access the site via Chrome or Firefox (these two browsers should exhibit the bug)
3. Go to dashboard and create a new supporter page
4. On the one-page form, enter a value into the address search, wait for values to populate in the dropdown
5. Mouse over the drop-down - the dropdown should immediately close and make it impossible to select a value.

This issue should affect anywhere the URLSearchInput component is used, but the only place we've had a report of it happening is above in `supporter`, hence those steps :P

### Related Jira ticket or GitHub issue numbers

JIRA ticket: TA-9685 (https://edhdev.atlassian.net/browse/TA-9685)

## Release Notes

- AddressLookup and AddressFieldsetWithLookup components should no longer prevent you from selecting an address from the populated dropdown.

