### PR TITLE
Add CI docker-compose file so that Buildkite passes again

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,5 @@
 tests:
-  build: .
+  image: "${DOCKER_REPOSITORY}:${COMMIT}"
   environment:
     - NPM_USER
     - NPM_PASS

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,9 @@
+tests:
+  build: .
+  environment:
+    - NPM_USER
+    - NPM_PASS
+    - NPM_EMAIL
+    - AWS_KEY
+    - AWS_SECRET
+    - BUILDKITE_MESSAGE


### PR DESCRIPTION
After updating .pipeline to the latest, buildkite's test execution was failing due to a missing `docker-compose.ci.yml` config file.