### PR TITLE
Add ability to sort filterSelect by label asc or desc.

### DIFF
--- a/DemoPage/examples/FilterSelect/index.js
+++ b/DemoPage/examples/FilterSelect/index.js
@@ -128,6 +128,7 @@ export default React.createClass({
           required
           errorMessage="Please select an option"
           value=" "
+          sort="asc"
           options={ options } />
 
         <FilterSelect

--- a/forms/FilterSelect/__tests__/FilterSelectInput-test.js
+++ b/forms/FilterSelect/__tests__/FilterSelectInput-test.js
@@ -35,6 +35,7 @@ describe('FilterSelect', () => {
       })
     })
   })
+
   describe('available options', () => {
     it('limits options passed to the option list to < props.maxResults', () => {
       let collection = [
@@ -181,6 +182,42 @@ describe('FilterSelect', () => {
         let subject = element.state.filteredOptions
 
         expect(subject).to.eql(options)
+      })
+    })
+
+    context('alphabetical', () => {
+      it('lists options alphabetically asc', () => {
+        let options = [
+          { value: '1', label: 'Zim Rogers' },
+          { value: '2', label: 'Kex Perkins' },
+          { value: '3', label: 'Ben Ely' }
+        ]
+        let subject = renderIntoDocument(
+          <FilterSelect options={ options } sort={ 'asc' } />
+        ).state.filteredOptions
+
+        expect(subject).to.eql([
+          { value: '3', label: 'Ben Ely' },
+          { value: '2', label: 'Kex Perkins' },
+          { value: '1', label: 'Zim Rogers' }
+        ])
+      })
+
+      it('lists options alphabetically desc', () => {
+        let options = [
+          { value: '2', label: 'Kex Perkins' },
+          { value: '3', label: 'Ben Ely' },
+          { value: '1', label: 'Zim Rogers' }
+        ]
+        let subject = renderIntoDocument(
+          <FilterSelect options={ options } sort={ 'desc' } />
+        ).state.filteredOptions
+
+        expect(subject).to.eql([
+          { value: '1', label: 'Zim Rogers' },
+          { value: '2', label: 'Kex Perkins' },
+          { value: '3', label: 'Ben Ely' }
+        ])
       })
     })
   })

--- a/forms/FilterSelect/index.js
+++ b/forms/FilterSelect/index.js
@@ -11,6 +11,7 @@ import OptionList from '../OptionList'
 import DisplayWrap from './DisplayWrap'
 import Filter from '../Filter'
 import classnames from 'classnames'
+import _ from 'lodash'
 
 export default React.createClass({
   displayName: 'FilterSelect',
@@ -41,7 +42,8 @@ export default React.createClass({
     Option: React.PropTypes.func,
     layout: React.PropTypes.string,
     spacing: React.PropTypes.string,
-    maxResults: React.PropTypes.number
+    maxResults: React.PropTypes.number,
+    sort: React.PropTypes.string
   },
 
   getDefaultProps () {
@@ -66,7 +68,8 @@ export default React.createClass({
       validate: () => {},
       layout: 'full',
       spacing: 'loose',
-      maxResults: 100
+      maxResults: 100,
+      sort: 'default'
     }
   },
 
@@ -75,7 +78,7 @@ export default React.createClass({
     return {
       focused: false,
       value: props.value || '',
-      filteredOptions: props.options.slice(0, props.maxResults),
+      filteredOptions: this.getOptions().slice(0, props.maxResults),
       selectedOption: this.getSelected(props.value, props.data),
       isOpen: false,
       filterValue: ''
@@ -95,10 +98,22 @@ export default React.createClass({
   getSelected(value, data) {
     value = value || ''
     const { valueKey } = this.props
-    return find(this.props.options, opt => (
+    return find(this.getOptions(), opt => (
       opt[valueKey] && opt[valueKey].toString() === value.toString()) ||
       isEqual(opt, data)
     )
+  },
+
+  getOptions() {
+    let options = this.props.options
+
+    if(this.props.sort === 'default') {
+      return options
+    }
+
+    options = _.sortBy(options, (option) =>  option.label )
+
+    return this.props.sort === 'asc' ? options : options.reverse()
   },
 
   handleFilter (filteredOptions) {
@@ -223,7 +238,6 @@ export default React.createClass({
 
   renderDisplay () {
     const {
-      options,
       id,
       label,
       name,
@@ -240,7 +254,7 @@ export default React.createClass({
     return (
       <DisplayWrap
         ref="displayInput"
-        options={ options }
+        options={ this.getOptions() }
         id={ id }
         label={ label }
         displayProperty={ displayProperty }
@@ -268,7 +282,6 @@ export default React.createClass({
 
     const {
       properties,
-      options,
       filterLabel,
       Option,
       labelKey,
@@ -287,7 +300,7 @@ export default React.createClass({
           focused
           filterValue={ filterValue }
           properties={ properties }
-          collection={ options }
+          collection={ this.getOptions() }
           label={ filterLabel }
           onChange={ this.handleFilterChange }
           onFilter={ this.handleFilter } />


### PR DESCRIPTION
Add ability to sort filterSelect by label asc or desc. Defaults to options array order if no sort set
### State

- [x] Ready for review
- [ ] Ready for merge

### Testing Notes

– View HUI sample page
– Find first FilterSelect 
– Results should be alphabetically sorted when you view the select and when you search

### Related Jira ticket or GitHub issue numbers

https://edhdev.atlassian.net/browse/TA-9380

## Release Notes

FilterSelect options can now be sorted

<img width="844" alt="screen shot 2016-06-13 at 12 02 09 pm" src="https://cloud.githubusercontent.com/assets/3256309/15995439/b3f3f888-315e-11e6-9a02-11dcd96c6cde.png">
<img width="836" alt="screen shot 2016-06-13 at 12 02 01 pm" src="https://cloud.githubusercontent.com/assets/3256309/15995440/b41dd52c-315e-11e6-80bf-b19779b65e02.png">
