### PR TITLE
Split out the tag component for re-use elsewhere (version 3)

### DIFF
--- a/assets.scss
+++ b/assets.scss
@@ -11,6 +11,7 @@
 @import "atoms/FlashMessage/style";
 @import "atoms/FlagIcon/style";
 @import "atoms/Tooltip/style";
+@import "atoms/Tag/style";
 
 // Buttons
 @import "buttons/Button/style";

--- a/atoms/Tag/index.js
+++ b/atoms/Tag/index.js
@@ -1,0 +1,17 @@
+'use strict'
+
+import React from 'react'
+
+export default React.createClass({
+  displayName: 'Tag',
+
+  render() {
+    return (
+      <div className="hui-Tag">
+        <div className="hui-Tag__label">
+          { this.props.children }
+        </div>
+      </div>
+    )
+  }
+})

--- a/atoms/Tag/style.scss
+++ b/atoms/Tag/style.scss
@@ -1,0 +1,12 @@
+.hui-Tag {
+  display: inline-block;
+  margin: $x-2 $x-2 $x-2 0;
+}
+
+.hui-Tag__label {
+  background-color: $grey-lighter;
+  padding: $x-1 $x-2;
+  border-radius: $border-radius;
+  color: $grey;
+  font-family: $font-copy;
+}

--- a/forms/TagList/Item/__tests__/index-test.js
+++ b/forms/TagList/Item/__tests__/index-test.js
@@ -2,30 +2,29 @@
 
 var TagListItem = require('../');
 
-describe('Tag List Item', function() {
-  describe('default', function() {
-    var item = { id: '1', name: 'foo' };
-    var onIconClick = sinon.spy();
-    var node, component;
+describe('Tag List Item', () => {
+  describe('default', () => {
+    const item = { id: '1', name: 'foo' }
+    const onIconClick = sinon.spy()
+    let component
 
-    beforeEach(function() {
-      component = renderIntoDocument(<TagListItem item={ item } onIconClick={ onIconClick } />);
-    });
+    beforeEach(() => {
+      component = renderIntoDocument(
+        <TagListItem
+          item={ item }
+          onIconClick={ onIconClick } />
+      )
+    })
 
-    it('should render tag name when it is present', function() {
-      node = findByClass(component, 'hui-TagListItem__label').getDOMNode();
-      expect(node.textContent).to.equal(item.name);
-    });
+    it('should render remove icon', () => {
+      findByClass(component, 'hui-TagListItem__iconButton')
+    })
 
-    it('should render remove icon', function() {
-      findByClass(component, 'hui-TagListItem__iconButton');
-    });
+    it('should call onIconClick when icon is clicked', () => {
+      const icon = findByClass(component, 'hui-TagListItem__iconButton')
+      TestUtils.Simulate.click(icon)
 
-    it('should call onIconClick when icon is clicked', function() {
-      var icon = findByClass(component, 'hui-TagListItem__iconButton');
-      TestUtils.Simulate.click(icon);
-
-      onIconClick.should.have.been.called;
-    });
-  });
-});
+      onIconClick.should.have.been.called
+    })
+  })
+})

--- a/forms/TagList/Item/index.js
+++ b/forms/TagList/Item/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var React      = require('react/addons');
-var Icon       = require('../../../atoms/Icon');
+import React from 'react/addons'
+import Icon from '../../../atoms/Icon'
+import Tag from '../../../atoms/Tag'
 
-module.exports = React.createClass({
+export default React.createClass({
   displayName: 'TagListItem',
 
   propTypes: {
@@ -12,43 +13,36 @@ module.exports = React.createClass({
     onIconClick: React.PropTypes.func.isRequired
   },
 
-  getDefaultProps: function() {
+  getDefaultProps() {
     return {
       item: {},
       icon: 'remove',
       onIconClick: null
-    };
+    }
   },
 
-  onClick: function(e) {
-    var props = this.props;
-    var onIconClick = props.onIconClick;
-    e.preventDefault();
-
-    return onIconClick && onIconClick(props.item);
+  onClick(e) {
+    const { onIconClick, item } = this.props
+    e.preventDefault()
+    return onIconClick && onIconClick(item)
   },
 
-  renderIcon: function() {
-    var props = this.props;
-    var icon = props.icon;
+  renderIcon() {
+    const { icon, item } = this.props
 
     return icon && (
-      <button id={ props.item.id } className="hui-TagListItem__iconButton" onClick={ this.onClick }>
+      <button id={ item.id } className="hui-TagListItem__iconButton" onClick={ this.onClick }>
         <Icon icon={ icon } fixedWidth={ true } />
       </button>
-    );
+    )
   },
 
-  render: function() {
-    var props = this.props;
-
+  render() {
     return (
-      <div className="hui-TagListItem">
-        <div className="hui-TagListItem__label">
-          { props.item.name }
-          { this.renderIcon() }
-        </div>
-      </div>
-    );
+      <Tag>
+        { this.props.item.name }
+        { this.renderIcon() }
+      </Tag>
+    )
   }
-});
+})

--- a/forms/TagList/Item/style.scss
+++ b/forms/TagList/Item/style.scss
@@ -1,20 +1,7 @@
-.hui-TagListItem {
-  display: inline-block;
-  margin: 8px 8px 8px 0;
-}
-
-.hui-TagListItem__label {
-  background-color: $grey-lighter;
-  padding: $x-1 $x-2;
-  border-radius: 6px;
-  color: $grey;
-  font-family: lato,helvetica,arial,sans-serif;
-}
-
 .hui-TagListItem__iconButton {
   border: 0;
   background-color: transparent;
   color: $grey;
   padding-left: $x-2;
+  cursor: pointer;
 }
-


### PR DESCRIPTION
Splits out the tag component from the tag list so that it can be re-used in isolation. Related to some work on ticket: https://edhdev.atlassian.net/browse/TA-9251

### State

- [x] Ready for review
- [x] Ready for merge

Note: Also did some general housekeeping with regards to semi-colons and ES6 syntax while I was in the neighbourhood.

Related PR for `master` branch: https://github.com/everydayhero/hui/pull/337