### PR TITLE
Enhance Filepicker error log behaviour.

### DIFF
--- a/lib/filepicker.js
+++ b/lib/filepicker.js
@@ -4,10 +4,22 @@ import 'console-polyfill'
 
 var filepicker = global.filepicker;
 
+const notLoadedError = () => {
+  throw new Error('The filepicker library is not loaded. ' +
+    'See https://www.filestack.com/')
+}
+
 if (filepicker) {
   filepicker.setKey(global.ENV.FILEPICKER_KEY);
 } else {
-  console.error('Filepicker library is not loaded.');
+  
+  // Only log the error if you're trying to actually use Filepicker library,
+  // since it's possible to load HUI but never use the Filepicker-driven
+  // components.
+  filepicker = {
+    setKey: notLoadedError,
+    pick: notLoadedError
+  }
 }
 
 export default filepicker


### PR DESCRIPTION
This is a "I'm sick of seeing that damn error" pull request.

The story is this: certain HUI components depend on the [filepicker](https://www.filestack.com) library. It's only supplied as a script that attaches itself as `window.filepicker`. So we have a shim script that checks if it exists and exports it, so components can import it explicitly. If filepicker isn't on the window, that shim logs an error.

Problem is, the error gets logged every time HUI's built bundle loads, whether your application is using one of the Filepicker-wrapping components or not.

This PR changes the shim so that we only log the error when some code tries to call the Filepicker functions. So unless you're using one of them (in which case the error is valid and you should be loading the Filepicker library via a script tag), you won't see the error anymore. It's now also being thrown as an actual error so you should get a stack trace to the component loading the shim.