### PR TITLE
Setup BUILD_MESSAGE env var for deploy

### DIFF
--- a/bin/buildkite
+++ b/bin/buildkite
@@ -16,6 +16,7 @@ export ANNOUNCE_EMAIL_TO="XXX"
 export APP="${APP:-hui}"
 export BRANCH="${BUILDKITE_BRANCH}"
 export BUILD_NUMBER="${BUILDKITE_BUILD_NUMBER}"
+export BUILD_MESSAGE="${BUILDKITE_MESSAGE}"
 export BUILD_URL="${BUILDKITE_BUILD_URL}"
 export COMMIT="${BUILDKITE_COMMIT}"
 export HEALTH_ENDPOINT='https://XXX.everydayhero.io/health'

--- a/bin/localkite
+++ b/bin/localkite
@@ -16,6 +16,7 @@ export ANNOUNCE_EMAIL_TO="XXX"
 export APP="${APP:-hui}"
 export BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 export BUILD_NUMBER="local"
+export BUILD_MESSAGE="x.x.x"
 export BUILD_URL="http://example.com/local-build"
 export COMMIT="$(git rev-parse HEAD)"
 export HEALTH_ENDPOINT='https://XXX.everydayhero.io/health'


### PR DESCRIPTION
This PR sets up the BUILD_MESSAGE to reference the buildkite env var for use within the deploy script (originally had localkite grab the version with `$(jq -r '.version' package.json)`... but though others may not have `jq` installed)

### State

- [x] Ready for review
- [x] Ready for merge