### PR TITLE
Allow layout and spacing to be overridden in reactForm.mixin

### DIFF
--- a/mixins/reactForm.mixin.js
+++ b/mixins/reactForm.mixin.js
@@ -87,6 +87,8 @@ module.exports = {
     options = options || {};
     var label = options.label || this.t(name + '_label');
     var hint = options.hint || this.t(name + '_hint', defaultMessage);
+    var layout = options.layout || "half"
+    var spacing = options.spacing || "fitted"
     var errors = this.props.errors || {};
 
     input = (
@@ -97,8 +99,8 @@ module.exports = {
         hint={ hint }
         onChange={  this.inputChangeEventFn(name) }
         className={ name }
-        layout="half"
-        spacing="fitted"
+        layout={ layout }
+        spacing={ spacing }
         errors={ options.errors || errors[name] }
         {...options} />
     );


### PR DESCRIPTION
I'm not sure why these are hard coded. There are places where this is expected to be modifiable. https://github.com/everydayhero/heroix/blob/master/ui/src/components/Partials/MigrateForm/index.js#L49

### State

- [x] Ready for review
- [x] Ready for merge

### Pre-merge Tasks

None

### Post-merge Tasks

- [ ] Do a release of HUI

### Testing Notes
None

### Related Jira ticket or GitHub issue numbers
Using this in [TA-8315](https://edhdev.atlassian.net/browse/TA-8315)

### Notes

None

## Release Notes

The above linked code may change the look of the form if it's relying on the option being ignored. More likely it's on an old version that doesn't have this bug.

