### PR TITLE
Compose multiple validators (and features to apply these in TextInput)

### DIFF
--- a/DemoPage/examples/TextInput/index.js
+++ b/DemoPage/examples/TextInput/index.js
@@ -4,6 +4,7 @@ import React              from 'react'
 import TextCountDownInput from '../../../forms/TextCountDownInput'
 import TextInput          from '../../../forms/TextInput'
 import formMixin          from '../../../mixins/reactForm.mixin'
+import validation         from '../../../lib/validation'
 
 export default React.createClass({
   displayName: 'TextInputExample',
@@ -35,8 +36,10 @@ export default React.createClass({
         id="demo_input"
         value={ this.state.form.demo_input_01 }
         label="Hint"
+        required={true}
         placeHolder="This is a placeholder"
-        onChange={ change('demo_input_01') } />
+        onChange={ change('demo_input_01') }
+        validate={ validation.compose('name', 'phone') } />
       <TextInput
         autoComplete={false}
         id="demo_input"

--- a/DemoPage/examples/TextInput/index.js
+++ b/DemoPage/examples/TextInput/index.js
@@ -4,7 +4,6 @@ import React              from 'react'
 import TextCountDownInput from '../../../forms/TextCountDownInput'
 import TextInput          from '../../../forms/TextInput'
 import formMixin          from '../../../mixins/reactForm.mixin'
-import validation         from '../../../lib/validation'
 
 export default React.createClass({
   displayName: 'TextInputExample',
@@ -36,10 +35,8 @@ export default React.createClass({
         id="demo_input"
         value={ this.state.form.demo_input_01 }
         label="Hint"
-        required={true}
         placeHolder="This is a placeholder"
-        onChange={ change('demo_input_01') }
-        validate={ validation.compose('name', 'phone') } />
+        onChange={ change('demo_input_01') } />
       <TextInput
         autoComplete={false}
         id="demo_input"

--- a/forms/AddressFieldset/index.js
+++ b/forms/AddressFieldset/index.js
@@ -92,7 +92,7 @@ export default React.createClass({
       value: this.state.form[name],
       required: methods && !!methods.length,
       showError: this.props.showError,
-      validate: methods && validation[methods[0]],
+      validate: methods && validation.compose(...methods),
       errorMessage: this.t(name + '_blank_error', { scope: this.state.countryCode }),
       spacing: this.props.internalSpacing,
       storeLocally: this.props.storeLocally,

--- a/forms/AddressFieldset/index.js
+++ b/forms/AddressFieldset/index.js
@@ -7,7 +7,6 @@ import isEqual from 'lodash/lang/isEqual'
 import classnames from 'classnames'
 import I18n from '../../mixins/I18n'
 import formControl from '../../mixins/formControl'
-import validation from '../../lib/validation'
 import Input from '../TextInput'
 import CountrySelect from '../CountrySelect'
 import countries from '../CountrySelect/countries'
@@ -92,7 +91,7 @@ export default React.createClass({
       value: this.state.form[name],
       required: methods && !!methods.length,
       showError: this.props.showError,
-      validate: methods && validation.compose(...methods),
+      validate: methods,
       errorMessage: this.t(name + '_blank_error', { scope: this.state.countryCode }),
       spacing: this.props.internalSpacing,
       storeLocally: this.props.storeLocally,

--- a/lib/__tests__/validation-test.js
+++ b/lib/__tests__/validation-test.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import _ from 'lodash'
+
+import validation from '../validation'
+
+describe('validation module', () => {
+  describe('#custom', () => {
+    it('should return the result of the validator function applied to the value', () => {
+      const testValidator = val => val === 'bob'
+      const testValue = 'bob'
+
+      const { valid: result } = validation.custom(testValidator, 'message', testValue)
+      expect(result).to.be.true
+
+      const invalidValue = 'not bob'
+      const { valid: invalidResult } = validation.custom(testValidator, 'test message', invalidValue)
+      expect(invalidResult).to.be.false
+    })
+
+    it('should return the message parameter as well (which generally will be partially applied)', () => {
+      const testValidator = val => val === 'bob'
+      const { message } = validation.custom(testValidator, 'test message', 'bob')
+      expect(message).to.equal('test message')
+    })
+
+    it('should call fn with the result of the validation if fn is passed', () => {
+      const testFn = sinon.stub()
+      validation.custom(() => true, 'test message', 'test value', testFn)
+      expect(testFn.called).to.be.true
+      expect(testFn.firstCall.args[0]).to.equal(true)
+    })
+  })
+
+  describe('#compose', () => {
+    let validatorA, validatorB
+
+    beforeEach(() => {
+      validatorA = _.partial(validation.custom, val => val === 'bob', 'Test message A')
+      validatorB = _.partial(validation.custom, val => val !== 'bob', 'Test message B')
+    })
+
+    it('should return a function', () => {
+      const composedValidator = validation.compose(validatorA, validatorB)
+      expect(typeof composedValidator).to.equal('function')
+    })
+
+    it('should evaluate to a nested array of the custom validator results', () => {
+      const composedValidator = validation.compose(validatorA, validatorB)
+      expect(composedValidator('bob')).to.deep.equal({
+        valid: false,
+        messages: ['Test message B']
+      })
+    })
+
+    it('should evaluate a string input to its preset validate function', () => {
+      const composedValidator = validation.compose(validatorA, 'cvv3', 'phone')
+      expect(composedValidator('bob')).to.deep.equal({
+        valid: false,
+        messages: [
+          'Your CVV is 3 digits located on the back of your card',
+          'Please enter your best contact number'
+        ]
+      })
+    })
+  })
+})

--- a/lib/__tests__/validation-test.js
+++ b/lib/__tests__/validation-test.js
@@ -1,34 +1,51 @@
 import { expect } from 'chai'
 import sinon from 'sinon'
-import _ from 'lodash'
 
 import validation from '../validation'
 
 describe('validation module', () => {
   describe('#custom', () => {
+    it('should return a validator function', () => {
+      const testValidator = () => true
+      const testMessage = 'test message'
+
+      expect(typeof validation.custom(testValidator, testMessage)).to.equal('function')
+    })
+
     it('should return the result of the validator function applied to the value', () => {
       const testValidator = val => val === 'bob'
       const testValue = 'bob'
 
-      const { valid: result } = validation.custom(testValidator, 'message', testValue)
+      const customValidator = validation.custom(testValidator, 'test error message')
+
+      const { valid: result } = customValidator(testValue)
       expect(result).to.be.true
 
       const invalidValue = 'not bob'
-      const { valid: invalidResult } = validation.custom(testValidator, 'test message', invalidValue)
+      const { valid: invalidResult } = customValidator(invalidValue)
       expect(invalidResult).to.be.false
     })
 
-    it('should return the message parameter as well (which generally will be partially applied)', () => {
+    it('should return the partially applied message parameter', () => {
       const testValidator = val => val === 'bob'
-      const { message } = validation.custom(testValidator, 'test message', 'bob')
-      expect(message).to.equal('test message')
+      const testMessage = 'test message'
+
+      const customValidator = validation.custom(testValidator, testMessage)
+
+      const { message } = customValidator('bob')
+      expect(message).to.equal(testMessage)
     })
 
-    it('should call fn with the result of the validation if fn is passed', () => {
+    it('should call fn with the result of the validation and error message if fn is passed', () => {
       const testFn = sinon.stub()
-      validation.custom(() => true, 'test message', 'test value', testFn)
+      const testMessage = 'test message'
+      const customValidator = validation.custom(() => true, testMessage)
+
+      customValidator('test value', testFn)
+
       expect(testFn.called).to.be.true
       expect(testFn.firstCall.args[0]).to.equal(true)
+      expect(testFn.firstCall.args[1]).to.equal(testMessage)
     })
   })
 
@@ -36,8 +53,8 @@ describe('validation module', () => {
     let validatorA, validatorB
 
     beforeEach(() => {
-      validatorA = _.partial(validation.custom, val => val === 'bob', 'Test message A')
-      validatorB = _.partial(validation.custom, val => val !== 'bob', 'Test message B')
+      validatorA = validation.custom(val => val === 'bob', 'Test message A')
+      validatorB = validation.custom(val => val !== 'bob', 'Test message B')
     })
 
     it('should return a function', () => {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -52,12 +52,36 @@ function isCreditCardExpiry(val, fn) {
   return valid
 }
 
-function customValidator (validator, message, val, fn) {
-  const valid = validator(val)
-  if (fn) { fn(valid, message) }
-  return { valid, message }
+/**
+ * Custom validator generator. Call this function with a simple true/false validation function and an
+ * error message describing failed validation, and get back a validator function with the same behaviour
+ * as the built-in validator functions
+ * @param {function(string)} validator function that should validate the passed input and return true or false
+ * @param {string} message The error message that you want to display if validation fails
+ * @returns {function(string, [function])} Generated validator function: call with a value and an optional
+ * on-validate callback, as per the built-in validation functions
+ */
+function customValidator (validator, message) {
+  return (val, fn) => {
+    const valid = validator(val)
+    if (fn) { fn(valid, message) }
+    return { valid, message }
+  }
 }
 
+/**
+ * Composes any combination of validators, generating a single validator function that will run the composed
+ * functions over a given input.
+ *
+ * @param {...function} validatorFunctions One or more validator functions, which can be any combination of:
+ *  - a string that corresponds to one of the built in validators, such as 'name', 'email', etc
+ *  - One of the built-in validator functions
+ *  - A custom validator function: the return value of validation.custom when called with a
+ *    custom validation function and an error message to display if validation fails.
+ * @returns {function(string, [function])} a validator function that will operate exactly like a built-in
+ * validator function, but will apply all the composed validators and return an object with
+ * { valid: bool, messages: [string]}
+ */
 function composeValidators (...validatorFunctions) {
   return (val, fn) => {
     const results = validatorFunctions.map(validator => {
@@ -66,7 +90,11 @@ function composeValidators (...validatorFunctions) {
         const message = validators[validator + 'Message']
         return { valid, message }
       } else {
-        return validator(val)
+        const validation = validator(val)
+        if (typeof validation === 'boolean') {
+          return { valid: validation }
+        }
+        return validation
       }
     }).filter(result => !result.valid)
     const valid = results.reduce((prev, curr) => curr.valid && prev, true)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -52,7 +52,33 @@ function isCreditCardExpiry(val, fn) {
   return valid
 }
 
-export default {
+function customValidator (validator, message, val, fn) {
+  const valid = validator(val)
+  if (fn) { fn(valid, message) }
+  return { valid, message }
+}
+
+function composeValidators (...validatorFunctions) {
+  return (val, fn) => {
+    const results = validatorFunctions.map(validator => {
+      if (typeof validator === 'string') {
+        const valid = validators[validator](val)
+        const message = validators[validator + 'Message']
+        return { valid, message }
+      } else {
+        return validator(val)
+      }
+    }).filter(result => !result.valid)
+    const valid = results.reduce((prev, curr) => curr.valid && prev, true)
+    const messages = results.map(result => result.message)
+
+    if (typeof fn === 'function') { fn(valid, messages) }
+
+    return { valid, messages }
+  }
+}
+
+const validators = {
   requiredMessage: 'This field cannot be left blank',
   required(val, fn) {
     return isRequired(val, fn)
@@ -86,5 +112,11 @@ export default {
   phoneMessage: 'Please enter your best contact number',
   phone(val, fn) {
     return isRequired(val) && isPhone(val, fn)
-  }
+  },
+
+  custom: customValidator,
+
+  compose: composeValidators
 }
+
+export default validators

--- a/mixins/formControl.js
+++ b/mixins/formControl.js
@@ -5,6 +5,7 @@
 import merge from 'lodash/object/merge'
 import isEmpty from 'lodash/lang/isEmpty'
 import cloneDeep from 'lodash/lang/cloneDeep'
+import isArray from 'lodash/lang/isArray'
 import React from 'react'
 import validation from '../lib/validation'
 
@@ -43,7 +44,8 @@ export default {
         showError={ state.showErrors }
         spacing="tight"
         required={ !!method }
-        validate={ typeof method === 'function' ? method : validation[method] }
+        validate={ isArray(method) ? method : [method] }
+        errors={ state.errors && state.errors[name] && state.errors[name].messages }
         errorMessage={ typeof method === 'string' && validation[method + 'Message'] } />
     )
   },
@@ -56,8 +58,8 @@ export default {
 
   onFieldError(key) {
     if (!this.errors) { this.errors = this.state.errors || {} }
-    return (bool) => {
-      this.errors[key] = bool
+    return (inError, messages = []) => {
+      this.errors[key] = { inError, messages }
       this.setErrors()
     }
   },

--- a/mixins/formControl.js
+++ b/mixins/formControl.js
@@ -43,8 +43,8 @@ export default {
         showError={ state.showErrors }
         spacing="tight"
         required={ !!method }
-        validate={ validation[method] }
-        errorMessage={ validation[method + 'Message'] } />
+        validate={ typeof method === 'function' ? method : validation[method] }
+        errorMessage={ typeof method === 'string' && validation[method + 'Message'] } />
     )
   },
 
@@ -56,7 +56,7 @@ export default {
 
   onFieldError(key) {
     if (!this.errors) { this.errors = this.state.errors || {} }
-    return bool => {
+    return (bool) => {
       this.errors[key] = bool
       this.setErrors()
     }

--- a/mixins/inputMessage.js
+++ b/mixins/inputMessage.js
@@ -12,8 +12,7 @@ export default {
   },
 
   shouldShowError() {
-    let props = this.props
-    let errors = props.errors || []
+    let errors = collectErrors(this.props, this.state) || []
 
     return this.state.hasError || errors.length
   },
@@ -21,14 +20,15 @@ export default {
   shouldRenderMessage () {
     const {
       hint,
-      errorMessage,
-      errors
+      errorMessage
     } = this.props
+
+    const errors = collectErrors(this.props, this.state) || []
 
     const { focused } = this.state
 
     return (!!errorMessage && this.shouldShowError()) ||
-           (!!(errors || []).length && this.shouldShowError()) ||
+           (!!errors.length && this.shouldShowError()) ||
            (!!hint && focused)
   },
 
@@ -36,8 +36,10 @@ export default {
     let props = this.props
     let message
 
+    const displayErrors = collectErrors(this.props, this.state)
+
     let errors = this.state.hasError
-      ? [props.errorMessage]
+      ? displayErrors || [props.errorMessage]
       : props.errors || []
 
     if (errors.length > 0) {
@@ -51,5 +53,14 @@ export default {
         { message }
       </div>
     )
+  }
+}
+
+function collectErrors(props, state) {
+  if (props.errors && props.errors.length) {
+    return props.errors
+  }
+  if (state.errors && state.errors.length) {
+    return state.errors
   }
 }

--- a/mixins/inputMessage.js
+++ b/mixins/inputMessage.js
@@ -12,31 +12,26 @@ export default {
   },
 
   shouldShowError() {
-    let errors = collectErrors(this.props, this.state) || []
+    let errors = this.props.errors || []
 
     return this.state.hasError || errors.length
   },
 
   shouldRenderMessage () {
     const {
-      hint,
-      errorMessage
+      hint
     } = this.props
-
-    const errors = collectErrors(this.props, this.state) || []
 
     const { focused } = this.state
 
-    return (!!errorMessage && this.shouldShowError()) ||
-           (!!errors.length && this.shouldShowError()) ||
-           (!!hint && focused)
+    return (this.shouldShowError()) || (!!hint && focused)
   },
 
   renderMessage() {
     let props = this.props
     let message
 
-    const displayErrors = collectErrors(this.props, this.state)
+    const displayErrors = collectErrors(this.props)
 
     let errors = this.state.hasError
       ? displayErrors || [props.errorMessage]
@@ -56,11 +51,8 @@ export default {
   }
 }
 
-function collectErrors(props, state) {
+function collectErrors(props) {
   if (props.errors && props.errors.length) {
     return props.errors
-  }
-  if (state.errors && state.errors.length) {
-    return state.errors
   }
 }

--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -173,8 +173,8 @@ export default {
 }
 
 function getValidator (validate) {
-  if (!isArray(validate)) {
-    validate = [validate]
+  if (isArray(validate)) {
+    return validation.compose(...validate)
   }
-  return validation.compose(...validate)
+  return validate
 }

--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -2,8 +2,10 @@
 
 import React from 'react'
 import { findDOMNode } from 'react-dom'
+import isArray from 'lodash/lang/isArray'
 import Icon from '../atoms/Icon'
 import classnames from 'classnames'
+import validation from '../lib/validation'
 
 export default {
   componentDidMount() {
@@ -37,18 +39,19 @@ export default {
     let { onChange, onError, validate, required } = props
 
     if (onChange) { onChange(value) }
-    if (onError && validate && required) { onError(!validate(value)) }
+    if (onError && validate && required) { onError(!getValidator(validate)(value)) }
   },
 
   validate(val) {
-    let props = this.props
-    if (!props.required) { return }
-    let value = val || this.props.value || ""
-    let hasValue = value && !!value.trim()
-    if (props.validate) {
+    const { validate, required, value: propValue } = this.props
+    if (!required) { return }
+    let value = val || propValue || ""
+
+    if (validate) {
       this.setState({ waiting: true })
-      props.validate(value, this.setValid)
+      getValidator(validate)(value, this.setValid)
     } else {
+      let hasValue = value && !!value.trim()
       this.setValid(hasValue)
     }
   },
@@ -82,13 +85,13 @@ export default {
   },
 
   handleBlur() {
-    let props = this.props
-    if (props.disabled || props.readOnly) { return }
+    let { disabled, readOnly, onBlur, value } = this.props
+    if (disabled || readOnly) { return }
 
     this.setState({ focused: false })
     this.validate()
-    if (props.onBlur) {
-      props.onBlur(props.value, val => {
+    if (onBlur) {
+      onBlur(value, val => {
         this.setValue(val);
         this.validate(val);
       });
@@ -99,7 +102,6 @@ export default {
     if (this.props.disabled || this.props.readOnly) { return }
     this.setState({
       hasError: false,
-      errors: [],
       valid: false,
       value: this.maskValue(value)
     })
@@ -108,10 +110,9 @@ export default {
 
   setValid(valid, errors = []) {
     let onError = this.props.onError
-    if (onError) { onError(!valid); }
+    if (onError) { onError(!valid, errors); }
     this.setState({
       hasError: !valid,
-      errors: errors,
       waiting: false,
       valid
     })
@@ -169,4 +170,11 @@ export default {
       onFocus: this.handleFocus
     }
   }
+}
+
+function getValidator (validate) {
+  if (!isArray(validate)) {
+    validate = [validate]
+  }
+  return validation.compose(...validate)
 }

--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -43,9 +43,9 @@ export default {
   validate(val) {
     let props = this.props
     if (!props.required) { return }
-    let value = val || this.props.value
+    let value = val || this.props.value || ""
     let hasValue = value && !!value.trim()
-    if (hasValue && props.validate) {
+    if (props.validate) {
       this.setState({ waiting: true })
       props.validate(value, this.setValid)
     } else {
@@ -99,17 +99,19 @@ export default {
     if (this.props.disabled || this.props.readOnly) { return }
     this.setState({
       hasError: false,
+      errors: [],
       valid: false,
       value: this.maskValue(value)
     })
     this.expose(value)
   },
 
-  setValid(valid) {
+  setValid(valid, errors = []) {
     let onError = this.props.onError
     if (onError) { onError(!valid); }
     this.setState({
       hasError: !valid,
+      errors: errors,
       waiting: false,
       valid
     })

--- a/mixins/textInputProps.js
+++ b/mixins/textInputProps.js
@@ -54,7 +54,10 @@ export const types = {
   mask: React.PropTypes.func,
   onFocus: React.PropTypes.func,
   onChange: React.PropTypes.func,
-  validate: React.PropTypes.func,
+  validate: React.PropTypes.oneOfType([
+    React.PropTypes.func,
+    React.PropTypes.array
+  ]),
   onError: React.PropTypes.func,
   onBlur: React.PropTypes.func,
   onTab: React.PropTypes.func,


### PR DESCRIPTION
Currently HUI's textInput mixin was predicated on a single validator for any field. This PR adds a validation.compose function that composes any number of validators (either string keys matching predefined HUI validations, or custom validator functions).

The PR also includes modifications for the textInput

The reason I'm putting the PR up before it's ready to merge (I want to enhance the other inputs to allow for composed validation also) is because the current HUI mechanism for validation and error display is kind of a shitshow: it uses either `state.errorMessage`, `state.errors` (sometimes an object, sometimes an array), and `props.errors` for error display. I haven't improved this yet, just made composed validators use `state.errors`, and could use some advice on what to do to clean it up.

Probably an ambitious refactor that removes the mixins (the interaction between 3 mixins: `textInput`, `inputMessage`, and `formControl` is most of what makes the validation and error display process so hard to follow), but I'm thinking it's well beyond the scope of my actual issue (which is doing credit card number checking in non-payment fields) 