### PR TITLE
Fix error display conditions

### DIFF
--- a/mixins/inputMessage.js
+++ b/mixins/inputMessage.js
@@ -19,12 +19,14 @@ export default {
 
   shouldRenderMessage () {
     const {
-      hint
+      hint,
+      errorMessage,
+      errors
     } = this.props
 
     const { focused } = this.state
 
-    return (this.shouldShowError()) || (!!hint && focused)
+    return (this.shouldShowError() && (errors.length || errorMessage)) || (!!hint && focused)
   },
 
   renderMessage() {
@@ -34,7 +36,7 @@ export default {
     const displayErrors = collectErrors(this.props)
 
     let errors = this.state.hasError
-      ? displayErrors || [props.errorMessage]
+      ? displayErrors || (props.errorMessage && [props.errorMessage]) || []
       : props.errors || []
 
     if (errors.length > 0) {


### PR DESCRIPTION
This fix adds a few more sanity checks for 'shouldDisplayError' so that it doesn't attempt to display the error box if there is no `errors` or `errorMessage` prop set. (For example, the Address search widget sets 'hasError' to display the error icon in the field, but the actual error messages are hooked up to the dropdown component.)