### PR TITLE
Allow masthead to take customised logo

### DIFF
--- a/layout/Masthead/__tests__/Masthead-test.js
+++ b/layout/Masthead/__tests__/Masthead-test.js
@@ -2,39 +2,65 @@
 
 import Masthead from '../index'
 
-describe('Masthead', function() {
-  describe('default', function() {
-    var component;
+describe('Masthead', () => {
+  let component;
 
-    beforeEach(function() {
+  describe('default', () => {
+    beforeEach(() => {
       document.implementation.hasFeature = () => true;
       component = renderIntoDocument(<Masthead imagePath="/" href="foo"/>);
     });
 
-    it('should render Masthead', function() {
+    it('should render Masthead', () => {
       component.should.exist;
     });
 
-    it('should not render application name', function() {
+    it('should not render application name', () => {
       scryByClass(component, 'hui-Masthead__appName').length.should.equal(0);
     });
 
-    it('should render a anchor with href foo', function() {
-      var href = findByTag(component, 'a').href;
+    it('should render a anchor with href foo', () => {
+      let href = findByTag(component, 'a').href;
 
       href.should.contain('foo');
     });
   });
 
-  describe('application Name', function() {
-    var component;
-
-    beforeEach(function() {
+  describe('application Name', () => {
+    beforeEach(() => {
       component = renderIntoDocument(<Masthead appName="foo" imagePath="/"/>);
     });
 
-    it('should render application name', function() {
+    it('should render application name', () => {
       scryByClass(component, 'hui-Masthead__appName').length.should.equal(1);
     });
+  });
+
+  describe('image', () => {
+    let img;
+
+    describe('with imagePath', () => {
+      beforeEach(() => {
+        component = renderIntoDocument(<Masthead imagePath="/" />);
+      });
+
+      it('should render an image with src of imagePath', () => {
+        img = findByClass(component, 'hui-Masthead__logo--desktop');
+
+        img.src.should.contain('hui_edh_logo@x2.gif');
+      });
+    });
+
+    describe('with desktopLogo', () => {
+      beforeEach(() => {
+        component = renderIntoDocument(<Masthead desktopLogo="foo/bar.jpg" />);
+      });
+
+      it('should render an image with src of desktopLogo', () => {
+        img = findByClass(component, 'hui-Masthead__logo--desktop');
+
+        img.src.should.contain('foo/bar.jpg');
+      });
+    })
   });
 });

--- a/layout/Masthead/index.js
+++ b/layout/Masthead/index.js
@@ -8,17 +8,19 @@ export default React.createClass({
   propTypes: {
     href: React.PropTypes.string,
     appName: React.PropTypes.string,
-    imagePath: React.PropTypes.string.isRequired
+    imagePath: React.PropTypes.string,
+    desktopLogo: React.PropTypes.string,
+    mobileLogo: React.PropTypes.string
   },
 
-  getDefaultProps: function() {
+  getDefaultProps () {
     return {
       root: '/'
     };
   },
 
-  renderAppName: function() {
-    var appName = this.props.appName;
+  renderAppName () {
+    const appName = this.props.appName;
 
     if (appName) {
       return (
@@ -31,20 +33,27 @@ export default React.createClass({
     }
   },
 
-  render: function() {
-    var alt = ['everydayhero', this.props.appName].join(' ');
+  render () {
+    const props = this.props;
+    const alt = ['everydayhero', props.appName].join(' ');
+    const desktopImagePath = props.imagePath
+      ? props.imagePath + 'hui_edh_logo@x2.gif'
+      : props.desktopLogo
+    const mobileImagePath = props.imagePath
+      ? props.imagePath + 'hui_edh_mark@x2.gif'
+      : props.mobileLogo
 
     return (
       <h1 className="hui-Masthead">
-        <a href={ this.props.href }>
+        <a href={ props.href }>
           <img
             className="hui-Masthead__logo--desktop"
-            src={ this.props.imagePath + 'hui_edh_logo@x2.gif' }
-            alt={ alt } />
+            src={desktopImagePath}
+            alt={alt} />
           <img
             className="hui-Masthead__logo--mobile"
-            src={ this.props.imagePath + 'hui_edh_mark@x2.gif' }
-            alt={ alt } />
+            src={mobileImagePath}
+            alt={alt} />
           { this.renderAppName() }
         </a>
       </h1>


### PR DESCRIPTION
Allow Masthead component to take customised logos. If `imagePath` is set it will pick up the path and ignore the logo you provided, so this should not break our existing application.

### State

- [x] Ready for review
- [x] Ready for merge
