### PR TITLE
Force android to respect initial address when prefill prop exists

### DIFF
--- a/forms/AddressFieldsetWithLookup/index.js
+++ b/forms/AddressFieldsetWithLookup/index.js
@@ -66,6 +66,12 @@ export default React.createClass({
     }
   },
 
+  componentWillMount() {
+    if (this.props.prefill) {
+      this.setState({ address: this.props.prefill })
+    }
+  },
+
   componentDidMount() {
     this.isAnyFieldRequired() && this.props.onError(isEmpty(this.state.address))
   },


### PR DESCRIPTION
This is a bit of a Hail Mary. It fixed the issue on Android Chrome, which was rendering with its `state.address` as null even though `getInitialState` returns a valid address in `this.props.prefill`. Manually calling setState with that prop before mounting fixes the initial setup, however when I removed that code everything was *still* working, even after I killed local storage.

So I'm confused.

In a working system, this is just a redundant setting of the initial address, so it shouldn't hurt anything. 