### PR TITLE
localStorage exception when saving kills React render

### DIFF
--- a/mixins/localStorage.js
+++ b/mixins/localStorage.js
@@ -33,15 +33,28 @@ function loadStateFromLocalStorage(component, done) {
   if (!settingState) done()
 }
 
+function isStorageAvailable() {
+  if (!ls) { return false }
+  try {
+    const TEST_KEY = 'test'
+    ls.setItem(TEST_KEY, '1')
+    ls.removeItem(TEST_KEY)
+
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
 export default {
   componentWillUpdate() {
-    if (!ls || !this.props.storeLocally) return
+    if (!isStorageAvailable() || !this.props.storeLocally) return
     let key = getLocalStorageKey(this)
     ls.setItem(key, JSON.stringify(this.state))
   },
 
-  componentWillMount () {
-    if (!ls || !this.props.storeLocally) return
+  componentWillMount() {
+    if (!isStorageAvailable() || !this.props.storeLocally) return
     loadStateFromLocalStorage(this, () => {
       ls.setItem(getLocalStorageKey(this), JSON.stringify(this.state))
     })


### PR DESCRIPTION
This was already handled in Supporter's `localStorage` mixin, but HUI either didn't have it (or it was removed). Basically, there is a specific scenario where `window.localStorage` exists, but if you try to save anything it throws a `QuotaExceededException` DOM error. Since our React components don't handle for that and use localStorage in lifecycle methods, it kills the initial render of most of the form components.

The specific scenario we have encountered is any version of Safari in Private Browsing mode, but it's a standard exception for Local Storage so it may happen in other places.

This PR adds silent opt-out of local storage features if saving would result in the aforementioned exception.