### PR TITLE
[TA-10462] Refactor and extend Tooltip component

### DIFF
--- a/DemoPage/Routes/Home/index.js
+++ b/DemoPage/Routes/Home/index.js
@@ -43,6 +43,7 @@ import RadioGroup from '../../examples/RadioGroup'
 import TextAreaLite from '../../examples/TextAreaLite'
 import IconButtons from '../../examples/IconButtons'
 import Table from '../../examples/Table'
+import Tooltip from '../../examples/Tooltip'
 
 const IMG_PATH = '../../images/'
 
@@ -106,6 +107,7 @@ export default React.createClass({
             <FilterSelect />
             <ImageInput />
             <FormRow />
+            <Tooltip />
             <Fieldset />
             <TagList />
             <AvatarInput />

--- a/DemoPage/examples/Tooltip/index.js
+++ b/DemoPage/examples/Tooltip/index.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import Tooltip from '../../../atoms/Tooltip'
+import Button from '../../../buttons/Button'
+
+let TooltipExample = () => {
+  const imgContent = (
+    <div>
+      <strong>Ol Billy Boy</strong>
+      <img src="https://www.fillmurray.com/200/200" alt="Ol' Billy Boy" />
+    </div>
+  )
+
+  return (
+    <div>
+      <h3 className="DemoPage__h3" id="FormRow">Tooltips</h3>
+
+      <div className="DemoPage__content">
+        <label>
+          Sometimes you just need a hint <Tooltip content="I'll stay until you click away" />
+        </label>
+      </div>
+
+      <div className="DemoPage__content">
+        <Tooltip
+          trigger="hover"
+          style="light"
+          position="center"
+          content="I'll only stay visible while you hover.">
+          <Button
+            kind="cta"
+            label="A component can also trigger a tooltip" />
+        </Tooltip>
+      </div>
+
+      <div className="DemoPage__content">
+        <p>Tooltips can contain rich content such as images as children. For example:</p>
+        <Tooltip
+          position="center"
+          style="light"
+          content={ imgContent }>
+          <strong>Click to view an attractive human.</strong>
+        </Tooltip>
+      </div>
+
+      <div className="DemoPage__content">
+        <p>Tooltips come in both light and dark varities:</p>
+
+        <Tooltip
+          trigger="hover"
+          style="dark"
+          position="center"
+          content="I'm a dark tooltip.">
+          <Button
+            kind="secondary"
+            label="Hover to see a dark tooltip" />
+        </Tooltip>
+
+        <Tooltip
+          trigger="hover"
+          style="light"
+          position="center"
+          content="I'm a light tooltip.">
+          <Button
+            kind="secondary"
+            label="Hover to see a light tooltip" />
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+TooltipExample.displayName = 'TooltipExample'
+
+export default TooltipExample

--- a/assets.scss
+++ b/assets.scss
@@ -11,6 +11,7 @@
 @import "atoms/FlashMessage/style";
 @import "atoms/FlagIcon/style";
 @import "atoms/Tooltip/style";
+@import "atoms/TooltipContent/style";
 @import "atoms/Tag/style";
 @import "atoms/Table/style";
 

--- a/atoms/Tooltip/__tests__/Tooltip-test.js
+++ b/atoms/Tooltip/__tests__/Tooltip-test.js
@@ -1,31 +1,52 @@
-'use strict'
-
+import { shallow } from 'enzyme'
 import Tooltip from '../'
-let tipText = 'This is some test tooltip text.'
+import TooltipContent from '../../TooltipContent'
+import Icon from '../../Icon'
 
 describe('Tooltip', () => {
-  let element
-
-  it('renders', () => {
-    element = renderIntoDocument(<Tooltip text={ tipText }/>)
-    findDOMNode(element).textContent.should.equal(tipText)
+  it('renders a TooltipContent component as a child', () => {
+    const wrapper = shallow(<Tooltip content="potato" />)
+    expect(wrapper.find(TooltipContent)).to.exist
+    expect(wrapper.find(TooltipContent).props()).to.eql({
+      style: 'dark',
+      position: 'left',
+      content: 'potato',
+      open: false
+    })
   })
 
-  it('can be opened and closed', () => {
-    element = renderIntoDocument(<Tooltip text={ tipText } />)
-    let tip = findByClass(element, 'Tooltip')
-    Simulate.click(tip)
-    element.state.open.should.equal(true)
-
-    let click = document.createEvent('HTMLEvents')
-    click.initEvent('click', true, true)
-    document.dispatchEvent(click)
-
-    element.state.open.should.equal(false)
+  it('renders an icon as a default trigger', () => {
+    const wrapper = shallow(<Tooltip />)
+    expect(wrapper.find('.hui-Tooltip__trigger')).to.exist
+    expect(wrapper.find(Icon)).to.exist
+    expect(wrapper.find(Icon).props().icon).to.equal('question-circle')
   })
 
-  it('can be placed on the right', () => {
-    element = renderIntoDocument(<Tooltip text={ tipText } side="right" />)
-    findByClass(element, 'Tooltip__tip--right')
+  it('can render a custom trigger', () => {
+    const wrapper = shallow(<Tooltip>click me</Tooltip>)
+    expect(wrapper.find('.hui-Tooltip__trigger')).to.exist
+    expect(wrapper.find('.hui-Tooltip__trigger').text()).to.equal('click me')
+  })
+
+  it('sets the tooltip to open when clicked', () => {
+    const wrapper = shallow(<Tooltip />)
+    const trigger = wrapper.find('.hui-Tooltip__trigger')
+
+    expect(wrapper.state().open).to.be.false
+    trigger.simulate('click')
+    expect(wrapper.state().open).to.be.true
+  })
+
+  context('when the trigger is set to hover', () => {
+    it('sets the tooltip to open when hovered', () => {
+      const wrapper = shallow(<Tooltip trigger="hover" />)
+      const trigger = wrapper.find('.hui-Tooltip__trigger')
+      expect(wrapper.state().open).to.be.false
+
+      trigger.simulate('mouseEnter')
+      expect(wrapper.state().open).to.be.true
+      trigger.simulate('mouseLeave')
+      expect(wrapper.state().open).to.be.false
+    })
   })
 })

--- a/atoms/Tooltip/index.js
+++ b/atoms/Tooltip/index.js
@@ -1,62 +1,76 @@
-'use strict'
-
-import React from 'react'
+import React, { Component, PropTypes } from 'react'
+import classNames from 'classnames'
 import { addEventBindings, removeEventBindings } from '../../lib/eventUtils'
-import cx from 'classnames'
 import Icon from '../Icon'
+import TooltipContent from '../TooltipContent'
 
-export default React.createClass({
-  displayName: 'Tooltip',
-
-  propTypes: {
-    className: React.PropTypes.string,
-    text: React.PropTypes.string.isRequired,
-    side: React.PropTypes.oneOf(['left', 'right'])
-  },
-
-  getDefaultProps() {
-    return {
-      side: 'left'
-    }
-  },
-
-  getInitialState() {
-    return {
-      open: false
-    }
-  },
+class Tooltip extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { open: false }
+    this.openTip = this.openTip.bind(this)
+    this.closeTip = this.closeTip.bind(this)
+  }
 
   openTip() {
     this.setState({ open: true })
-    addEventBindings('click', this.closeTip, document)
-  },
+
+    if (this.props.trigger === 'click') {
+      addEventBindings('click', this.closeTip, document)
+    }
+  }
 
   closeTip() {
     this.setState({ open: false })
-    removeEventBindings('click', this.closeTip, document)
-  },
+
+    if (this.props.trigger === 'click') {
+      removeEventBindings('click', this.closeTip, document)
+    }
+  }
 
   render() {
-    var props = this.props
-    var classes = cx({
-      'Tooltip': true,
-      'Tooltip--open': this.state.open
-    })
-    var tipClasses = cx({
-      'Tooltip__tip': true,
-      'Tooltip__tip--left': props.side === 'left',
-      'Tooltip__tip--right': props.side === 'right'
+    const { trigger } = this.props
+    const classes = classNames({
+      'hui-Tooltip': true,
+      'hui-Tooltip--open': this.state.open,
+      'hui-Tooltip--hoverable': trigger === 'hover',
+      [this.props.className]: !!this.props.className
     })
 
     return (
-      <div className={ classes + ' ' + props.className } onClick={ this.openTip }>
-        <Icon icon="question-circle" className="Tooltip__icon" />
-        <div className={ tipClasses }>
-          <div className="Tooltip__tip__text">
-            { props.text }
-          </div>
+      <div className={ classes }>
+        <div className="hui-Tooltip__trigger"
+          onClick={ trigger === 'click' && this.openTip }
+          onMouseEnter={ trigger === 'hover' && this.openTip }
+          onMouseLeave={ trigger === 'hover' && this.closeTip }>
+          { this.props.children || <Icon icon="question-circle" className="hui-Tooltip__icon" /> }
         </div>
+        <TooltipContent
+          style={ this.props.style }
+          position={ this.props.position }
+          content={ this.props.content }
+          open={ this.state.open } />
       </div>
     )
   }
-})
+}
+
+Tooltip.displayName = 'Tooltip',
+Tooltip.propTypes = {
+  className: PropTypes.string,
+  trigger: PropTypes.oneOf(['click', 'hover']),
+  style: PropTypes.oneOf(['light', 'dark']),
+  position: PropTypes.oneOf(['left', 'right', 'center']),
+  content: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node
+  ])
+}
+Tooltip.defaultProps = {
+  trigger: 'click',
+  style: 'dark',
+  position: 'left',
+  content: ''
+}
+
+export default Tooltip

--- a/atoms/Tooltip/style.scss
+++ b/atoms/Tooltip/style.scss
@@ -1,82 +1,24 @@
-.Tooltip {
+.hui-Tooltip {
+  font-family: $font-copy;
+  display: inline-block;
   position: relative;
   z-index: 1;
-  width: $x-11;
-  height: $x-11;
-  padding: $x-2;
-  line-height: $x-7;
   text-align: center;
   cursor: pointer;
   user-select: none;
 }
 
-.Tooltip__icon {
+.hui-Tooltip__icon {
   transition: all 160ms ease-out;
   color: $grey-light;
   font-size: 18px;
   opacity: 0.7;
+  width: $x-11;
+  height: $x-11;
+  padding: $x-2;
+  line-height: $x-7;
 }
 
-.Tooltip--open .Tooltip__icon {
+.hui-Tooltip--open .hui-Tooltip__icon {
   opacity: 1;
-}
-
-.Tooltip__tip {
-  transition: all 160ms ease-out;
-  display: block;
-  transform: scale(0.1);
-  visibility: hidden;
-  opacity: 0;
-  width: $x-54;
-  padding: $x-4;
-  position: absolute;
-  z-index: 10;
-  bottom: 100%;
-  background-color: #525252;
-  color: #fff;
-  font-size: 11px;
-  line-height: 14px;
-  pointer-events: none;
-}
-
-.Tooltip__tip::after {
-  content: '';
-  display: block;
-  position: absolute;
-  top: 100%;
-  width: 0;
-  height: 0;
-  border-top: $x-2 solid #525252;
-}
-
-.Tooltip__tip--left {
-  right: 50%;
-  border-radius: 2px 2px 0 2px;
-  transform-origin: bottom right;
-}
-
-.Tooltip__tip--left::after {
-  right: 0;
-  border-left: $x-2 solid transparent;
-}
-
-.Tooltip__tip--right {
-  left: 50%;
-  border-radius: 2px 2px 2px 0;
-  transform-origin: bottom left;
-}
-
-.Tooltip__tip--right::after {
-  left: 0;
-  border-right: $x-2 solid transparent;
-}
-
-.Tooltip__tip__text {
-  overflow: hidden;
-}
-
-.Tooltip--open .Tooltip__tip {
-  transform: scale(1);
-  opacity: 1;
-  visibility: visible;
 }

--- a/atoms/TooltipContent/__tests__/TooltipContent-test.js
+++ b/atoms/TooltipContent/__tests__/TooltipContent-test.js
@@ -1,0 +1,102 @@
+import { shallow } from 'enzyme'
+import TooltipContent from '../'
+
+describe('TooltipContent', () => {
+  it('applies a class when set to open', () => {
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="light"
+        position="center"
+        content="foobar" />
+    )
+
+    expect(wrapper.hasClass('hui-TooltipContent--open')).to.equal(true)
+  })
+
+  it('applies a class when style is set to light', () => {
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="light"
+        position="center"
+        content="foobar" />
+    )
+
+    expect(wrapper.hasClass('hui-TooltipContent--light')).to.equal(true)
+  })
+
+  it('applies a class when style is set to dark', () => {
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="dark"
+        position="center"
+        content="foobar" />
+    )
+
+    expect(wrapper.hasClass('hui-TooltipContent--dark')).to.equal(true)
+  })
+
+  it('applies a class when position is set to left', () => {
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="light"
+        position="left"
+        content="foobar" />
+    )
+
+    expect(wrapper.hasClass('hui-TooltipContent--left')).to.equal(true)
+  })
+
+  it('applies a class when position is set to right', () => {
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="light"
+        position="right"
+        content="foobar" />
+    )
+
+    expect(wrapper.hasClass('hui-TooltipContent--right')).to.equal(true)
+  })
+
+  it('applies a class when position is set to center', () => {
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="light"
+        position="center"
+        content="foobar" />
+    )
+
+    expect(wrapper.hasClass('hui-TooltipContent--center')).to.equal(true)
+  })
+
+  it('can render a string as child content', () => {
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="light"
+        position="left"
+        content="foobar" />
+    )
+
+    expect(wrapper.text()).to.equal('foobar')
+  })
+
+  it('can render a node as child content', () => {
+    const content = <span className="customContentNode">Life is good inside a span tag</span>
+    const wrapper = shallow(
+      <TooltipContent
+        open={ true }
+        style="light"
+        position="left"
+        content={ content } />
+    )
+
+    expect(wrapper.find('.customContentNode').type()).to.equal('span')
+    expect(wrapper.find('.customContentNode').text()).to.equal('Life is good inside a span tag')
+  })
+})

--- a/atoms/TooltipContent/index.js
+++ b/atoms/TooltipContent/index.js
@@ -1,0 +1,35 @@
+import React, { PropTypes } from 'react'
+import classNames from 'classnames'
+
+let TooltipContent = ({ style, position, content, open }) => {
+  const classes = classNames({
+    'hui-TooltipContent': true,
+    'hui-TooltipContent--open': open,
+    'hui-TooltipContent--light': style === 'light',
+    'hui-TooltipContent--dark': style === 'dark',
+    'hui-TooltipContent--left': position === 'left',
+    'hui-TooltipContent--center': position === 'center',
+    'hui-TooltipContent--right': position === 'right'
+  })
+
+  return (
+    <div className={ classes }>
+      <div className="hui-TooltipContent__content">
+        { content }
+      </div>
+    </div>
+  )
+}
+
+TooltipContent.displayName = 'TooltipContent'
+TooltipContent.propTypes = {
+  open: PropTypes.bool.isRequired,
+  style: PropTypes.oneOf(['light', 'dark']).isRequired,
+  position: PropTypes.oneOf(['left', 'right', 'center']).isRequired,
+  content: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node
+  ]).isRequired
+}
+
+export default TooltipContent

--- a/atoms/TooltipContent/style.scss
+++ b/atoms/TooltipContent/style.scss
@@ -1,0 +1,101 @@
+.hui-TooltipContent {
+  transition: all 160ms ease-out;
+  display: block;
+  transform: scale(0.1);
+  visibility: hidden;
+  opacity: 0;
+  min-width: $x-54;
+  padding: $x-4;
+  margin-bottom: $x-1;
+  position: absolute;
+  z-index: 10;
+  bottom: 100%;
+  font-size: 11px;
+  line-height: 14px;
+  pointer-events: none;
+  box-shadow: 0 1px 3px rgba($grey-dark, 0.15);
+
+  &::before,
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 100%;
+    width: 0;
+    height: 0;
+    border-top: $x-2 solid;
+    margin-top: -1px;
+  }
+
+  &::before {
+    margin-top: 0px;
+    border-top-color: rgba($grey-dark, 0.15)
+  }
+
+  &--open {
+    transform: scale(1);
+    opacity: 1;
+    visibility: visible;
+  }
+
+  &--left {
+    right: 50%;
+    border-radius: $border-radius $border-radius 0 $border-radius;
+    transform-origin: bottom right;
+  }
+
+  &--left::before,
+  &--left::after {
+    right: 0;
+    border-left: $x-2 solid transparent;
+  }
+
+  &--right {
+    left: 50%;
+    border-radius: $border-radius $border-radius $border-radius 0;
+    transform-origin: bottom left;
+  }
+
+  &--right::before,
+  &--right::after {
+    left: 0;
+    border-right: $x-2 solid transparent;
+  }
+
+  &--center {
+    left: 50%;
+    transform: scale(1) translateX(-50%);
+    border-radius: $border-radius;
+    transform-origin: bottom center;
+  }
+
+  &--center::before,
+  &--center::after {
+    left: 50%;
+    transform: translateX(-50%);
+    border-left: $x-2 solid transparent;
+    border-right: $x-2 solid transparent;
+  }
+
+  &--dark {
+    background-color: $grey;
+    color: #fff;
+  }
+
+  &--dark::after {
+    border-top-color: $grey;
+  }
+
+  &--light {
+    background-color: #fff;
+    color: $grey-dark;
+  }
+
+  &--light::after {
+    border-top-color: #fff;
+  }
+}
+
+.hui-TooltipContent__content {
+  overflow: hidden;
+}


### PR DESCRIPTION
Extends the existing `Tooltip` component to be more flexible in the positioning, colour and trigger mechanism.

![oct-05-2016 11-24-12](https://cloud.githubusercontent.com/assets/859298/19098156/590233b0-8aee-11e6-8b77-073158311b47.gif)

### State

- [x] Ready for review
- [x] Ready for merge

### Notes

#### Includes breaking changes:

- Where previously the `Tooltip` component took a `text` prop it now takes a prop called `content`. This change was made to be more generic given the tooltip can display richer content, such as formatted text, links or images.
- The `side` prop has also been renamed, it is now `position`. This is because the tooltip now supports being set to `'center'` as well as the `'left'` and `'right'`.

#### Non-breaking changes:

- Tooltips can be triggered by click or hover.
- The tooltip still uses a question mark icon as the default trigger, but you can wrap the tooltip around any other text, component or node to change the trigger.
- Tooltips can be set to either dark or light variants, where the background and text colour is changes respectively.