### PR TITLE
Patch flickering test with calledWithMatch

### DIFF
--- a/forms/UrlSearchSelect/__tests__/URLSearchSelectInput-test.js
+++ b/forms/UrlSearchSelect/__tests__/URLSearchSelectInput-test.js
@@ -49,11 +49,13 @@ describe('UrlSearchSelect', () => {
 
     it('calls getJSON with a params object containing props.params and q: state.queryValue', () => {
       let element = renderIntoDocument(
-        <UrlSearchSelect params={ { some: 'Param' }  }  url="http://everydayhero.com" />
+        <UrlSearchSelect
+          params={{ some: 'Param' }}
+          url="http://everydayhero.com" />
       )
       element.fetchResults('foobar')
 
-      expect(mockGetJSON).calledWith('http://everydayhero.com', {
+      expect(mockGetJSON).calledWithMatch('http://everydayhero.com', {
         q: 'foobar',
         some: 'Param'
       })


### PR DESCRIPTION
This test was super wack and holding up PR's; Passing locally but failing on buildkite. For whatever reason a `__jsonp` key was being included in the object that `mockGetJSON` is called with...

As a small fix using `calledWithMatch` will be less strict and not care about extra keys.

Also fixed some terrible whitespace.

### State

- [x] Ready for review
- [x] Ready for merge