### PR TITLE
Recommend `npm test` instead of `npm run test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ gulp                  # build all production assets
 $ gulp --debug          # build all unminified assets (for debugging)
 $ gulp scripts          # build script assest (Can also use the --debug flag)
 $ gulp styles           # build styles assest (Can also use the --debug flag)
-$ npm run test          # run all tests
+$ npm test              # run all tests
 $ npm start             # run local server to view demo page
 ```
 


### PR DESCRIPTION
The generic `npm run <script>` will output copious amounts of debug
information when the script exits with a failure status. Since tests are
expected to fail, the `npm test` entry point should be used to run tests
as it will suppress this output.