### PR TITLE
Allow error props to be passed down to URLSearchSelectInput

### DIFF
--- a/forms/AddressFieldsetWithLookup/index.js
+++ b/forms/AddressFieldsetWithLookup/index.js
@@ -32,6 +32,8 @@ export default React.createClass({
     onError: React.PropTypes.func,
     onUnmount: React.PropTypes.func,
     showError: React.PropTypes.bool,
+    errors: React.PropTypes.array,
+    errorMessage: React.PropTypes.string,
     storeLocally: React.PropTypes.bool,
     validations: React.PropTypes.shape({
       street_address: React.PropTypes.array,
@@ -149,7 +151,8 @@ export default React.createClass({
       <AddressLookup
         ref="lookup"
         required={ this.isAnyFieldRequired() }
-        errorMessage={ this.t('error_message') }
+        errorMessage={ this.props.errorMessage || this.t('error_message') }
+        errors={ this.props.errors }
         spacing={ this.props.spacing }
         countryCode={ this.state.countryCode }
         selectedCountry={ this.state.country }

--- a/forms/AddressLookup/index.js
+++ b/forms/AddressLookup/index.js
@@ -22,6 +22,8 @@ export default React.createClass({
   propTypes: {
     layout: React.PropTypes.string,
     required: React.PropTypes.bool,
+    errors: React.PropTypes.array,
+    errorMessage: React.PropTypes.string,
     showError: React.PropTypes.bool,
     spacing: React.PropTypes.string,
     countryCode: React.PropTypes.string,
@@ -162,13 +164,14 @@ export default React.createClass({
           pendingRequest={ !!state.pendingRequest }
           required={ props.required }
           errorMessage={ props.errorMessage }
+          errors={ props.errors }
           emptyLabel={ props.emptyLabel || this.t('empty_label', { scope: state.selectedCountry.value }) }
           manualAction={ props.manualAction }
           minQueryLength={ state.minQueryLength }
           deserializeResponse={ this.deserializeAddressesResponse }
-          showError={ this.props.showError }
-          onError={ this.props.onError }
-          onChange={ this.props.onChange }
+          showError={ props.showError }
+          onError={ props.onError }
+          onChange={ props.onChange }
           onSelection={ this.handleAddressSelection } />
         <CountrySelect
           ref="countrySelect"

--- a/forms/UrlSearchSelect/__tests__/URLSearchSelectInput-test.js
+++ b/forms/UrlSearchSelect/__tests__/URLSearchSelectInput-test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import Promise from 'bluebird'
+import { mount } from 'enzyme'
 
 const proxyquire = require('proxyquire')
   .noCallThru()
@@ -166,6 +167,52 @@ describe('UrlSearchSelect', () => {
         expect(element.state.hasError).to.eq(true)
         done()
       }, 110)
+    })
+  })
+
+  describe('manual error rendering', () => {
+    context('when an errors prop is set', () => {
+      it('renders the errors from errors array', () => {
+        const wrapper = mount(
+          <UrlSearchSelect
+            required
+            errors={['I got you, you rookie b#&*$!']}
+            url="http://everydayhero.com" />
+        )
+
+        expect(wrapper.find('.hui-InputErrors').length).to.equal(1)
+        expect(wrapper.find('.hui-InputErrors').text()).to.contain('I got you, you rookie b#&*$!')
+      })
+    })
+
+    context('when an errorMessage prop is set', () => {
+      it('will render the error message if the showError prop is set to true', () => {
+        const wrapper = mount(
+          <UrlSearchSelect
+            required
+            showError
+            errorMessage="You have failed, just like everything in your life."
+            url="http://everydayhero.com"
+            required
+            errors={['You have failed, just like everything in your life.']}
+            url="http://everydayhero.com" />
+        )
+
+        expect(wrapper.find('.hui-InputErrors').length).to.equal(1)
+        expect(wrapper.find('.hui-InputErrors').text())
+          .to.contain('You have failed, just like everything in your life.')
+      })
+
+      it('will not render the error message by default', () => {
+        const wrapper = mount(
+          <UrlSearchSelect
+            required
+            showError={ false }
+            errorMessage="You have failed, just like everything in your life." />
+        )
+
+        expect(wrapper.find('.hui-InputErrors').length).to.equal(0)
+      })
     })
   })
 })

--- a/forms/UrlSearchSelect/index.js
+++ b/forms/UrlSearchSelect/index.js
@@ -229,11 +229,13 @@ export default React.createClass({
           value={ state.queryValue }
           icon={ inputIcon }
           label={ props.label }
-          showError={ state.hasError }
+          showError={ props.showError || state.hasError }
           required={ props.required }
           onKeyDown={ this.handleKeyDown }
           onError={ props.onError }
-          onChange={ this.handleSearchInputChange }/>
+          onChange={ this.handleSearchInputChange }
+          errorMessage={ props.errorMessage }
+          errors={ props.errors } />
         { state.isOpen ?
           <div className="hui-UrlSearchSelect__dropdown">
             <OptionList
@@ -250,8 +252,6 @@ export default React.createClass({
                 { props.manualAction }
               </div> }
           </div> : null }
-
-        { this.renderMessage() }
       </div>
     )
   },


### PR DESCRIPTION
This solves a problem which we surfaced in `warp-gate` with the `AddressFieldsetWithLookup` component. If the user doesn't even touch the address search field then no errors are shown – turns out the thing just didn't accept `errors` or `errorMessage` props making it unlike every other form input component in HUI.

### State

- [x] Ready for review
- [x] Ready for merge
