### PR TITLE
Topic/include absense of creditcard validation

### DIFF
--- a/lib/__tests__/creditCards-test.js
+++ b/lib/__tests__/creditCards-test.js
@@ -1,0 +1,28 @@
+import creditCards from '../creditCards'
+
+describe('containsValidCard', () => {
+  it('should return true if the text contains a valid card number in its content', () => {
+    const containsAmex = 'Please use my card for $10: 376361091078164. Thanks, Bob'
+    expect(creditCards.containsValidCard(containsAmex)).to.be.true
+  })
+
+  it('should return true if there is a CC number that includes hyphens', () => {
+    const containsMC = 'This is my number, please steal my money: 5174-3510-4414-8571.'
+    expect(creditCards.containsValidCard(containsMC)).to.be.true
+  })
+
+  it('should return true if there is a CC number that includes spaces', () => {
+    const containsDiscover = 'Steal this card! 6011 2690 3613 9223'
+    expect(creditCards.containsValidCard(containsDiscover)).to.be.true
+  })
+
+  it('should return false if there is an invalid number in there', () => {
+    const invalidString = 'This is not really a CC number: 6011 1234 1234 1234'
+    expect(creditCards.containsValidCard(invalidString)).to.be.false
+  })
+
+  it('should return false if there is nothing that looks like a card number', () => {
+    const noWorries = 'This is just a regular text value! No cards here, sir.'
+    expect(creditCards.containsValidCard(noWorries)).to.be.false
+  })
+})

--- a/lib/creditCards.js
+++ b/lib/creditCards.js
@@ -249,7 +249,7 @@ function getLikelyMatch (num) {
 
 function getPossibleMatches (num) {
   return map(cardTypes, function (d) {
-    var match = flatten(isMatch(d.iin, num))
+    const match = flatten(isMatch(d.iin, num))
     if (match.length) { return { key: d.key, priority: match[0] } }
   })
 }
@@ -269,7 +269,7 @@ function isInRange (arr, num) {
 
 // Card validation methods
 function validate (num) {
-  var type = getLikelyMatch(num)
+  const type = getLikelyMatch(num)
   if (!type || !isValidLength(type, num)) { return false }
   return !getCardType(type).validate || luhnTest(num)
 }
@@ -300,7 +300,7 @@ export default {
     return getCardType(key).name
   },
   validateCard: function (num, fn) {
-    var valid = validate(clean(num))
+    const valid = validate(clean(num))
     if (fn) { fn(valid, errorMessage) }
     return valid
   },

--- a/lib/creditCards.js
+++ b/lib/creditCards.js
@@ -1,0 +1,324 @@
+import find from 'lodash/find'
+import forEach from 'lodash/forEach'
+import map from 'lodash/map'
+import filter from 'lodash/filter'
+import compact from 'lodash/compact'
+import flatten from 'lodash/flatten'
+import range from 'lodash/range'
+import result from 'lodash/result'
+
+const cardTypes = [
+  {
+    key: 'australian_bankcard',
+    name: 'Australian BankCard',
+    iin: [
+      [5610],
+      [560221, 560225]
+    ],
+    length: [
+      [16]
+    ],
+    validate: true
+  },
+  {
+    key: 'american_express',
+    name: 'American Express',
+    iin: [
+      [34],
+      [37]
+    ],
+    length: [
+      [15]
+    ],
+    validate: true
+  },
+  {
+    key: 'china_unionpay',
+    name: 'China UnionPay',
+    iin: [
+      [62],
+      [88]
+    ],
+    length: [
+      [16, 19]
+    ],
+    validate: false
+  },
+  {
+    key: 'diners_club_enroute',
+    name: 'Diners Club enRoute',
+    iin: [
+      [2014],
+      [2149]
+    ],
+    length: [
+      [15]
+    ],
+    validate: false
+  },
+  {
+    key: 'diners_club',
+    name: 'Diners Club',
+    iin: [
+      [300, 305],
+      [309],
+      [36],
+      [38, 39]
+    ],
+    length: [
+      [14],
+      [16]
+    ],
+    validate: true
+  },
+  {
+    key: 'discover',
+    name: 'Discover Card',
+    iin: [
+      [6011],
+      [622126, 622925],
+      [644, 649],
+      [65]
+    ],
+    length: [
+      [16]
+    ],
+    validate: true
+  },
+  {
+    key: 'interpayment',
+    name: 'InterPayment',
+    iin: [
+      [636]
+    ],
+    length: [
+      [16, 19]
+    ],
+    validate: true
+  },
+  {
+    key: 'jcb',
+    name: 'Japan Credit Bureau',
+    iin: [
+      [3528, 3589]
+    ],
+    length: [
+      [16]
+    ],
+    validate: true
+  },
+  {
+    key: 'laser',
+    name: 'Laser',
+    iin: [
+      [6304],
+      [6706],
+      [6771],
+      [6709]
+    ],
+    length: [
+      [16, 19]
+    ],
+    validate: true
+  },
+  {
+    key: 'maestro',
+    name: 'Maestro',
+    iin: [
+      [5018],
+      [5020],
+      [5038],
+      [5612],
+      [5893],
+      [6304],
+      [6759],
+      [6761],
+      [6762],
+      [6763],
+      ['0604'],
+      [6390]
+    ],
+    length: [
+      [12, 19]
+    ],
+    validate: true
+  },
+  {
+    key: 'dankort',
+    name: 'Dankort',
+    iin: [
+      [5019]
+    ],
+    length: [
+      [11],
+      [16]
+    ],
+    validate: true
+  },
+  {
+    key: 'mastercard',
+    name: 'MasterCard',
+    iin: [
+      [50, 55]
+    ],
+    length: [
+      [16]
+    ],
+    validate: true
+  },
+  {
+    key: 'solo',
+    name: 'Solo',
+    iin: [
+      [6334],
+      [6767]
+    ],
+    length: [
+      [16],
+      [18, 19]
+    ],
+    validate: true
+  },
+  {
+    key: 'switch',
+    name: 'Switch',
+    iin: [
+      [4903],
+      [4905],
+      [4911],
+      [4936],
+      [564182],
+      [633110],
+      [6333],
+      [6759]
+    ],
+    length: [
+      [16],
+      [18, 19]
+    ],
+    validate: true
+  },
+  {
+    key: 'visa',
+    name: 'Visa',
+    iin: [
+      [4]
+    ],
+    length: [
+      [13],
+      [16]
+    ],
+    validate: true
+  },
+  {
+    key: 'visa_electron',
+    name: 'Visa Electron',
+    iin: [
+      [4026],
+      [417500],
+      [4405],
+      [4508],
+      [4844],
+      [4913],
+      [4917]
+    ],
+    length: [
+      [16]
+    ],
+    validate: true
+  }
+]
+
+// Card matching
+function getCardType (type) {
+  return find(cardTypes, { key: type })
+}
+
+function getLikelyMatch (num) {
+  const matches = compact(getPossibleMatches(num))
+  let key = ''
+  let val = 0
+  forEach(matches, function (d) {
+    if (d.priority > val) {
+      key = d.key
+      val = d.priority
+    }
+  })
+  return key
+}
+
+function getPossibleMatches (num) {
+  return map(cardTypes, function (d) {
+    var match = flatten(isMatch(d.iin, num))
+    if (match.length) { return { key: d.key, priority: match[0] } }
+  })
+}
+
+function isMatch (arr, num) {
+  return filter(arr, function (d) {
+    if (d.length > 1) { return isInRange(d, num) }
+    return num.indexOf(d) === 0
+  })
+}
+
+function isInRange (arr, num) {
+  return !!filter(range(arr[0], arr[1] + 1), function (d) {
+    return num.indexOf(d) === 0
+  }).length
+}
+
+// Card validation methods
+function validate (num) {
+  var type = getLikelyMatch(num)
+  if (!type || !isValidLength(type, num)) { return false }
+  return !getCardType(type).validate || luhnTest(num)
+}
+
+function isValidLength (type, num) {
+  return !!isMatch(getCardType(type).length, num.length.toString()).length
+}
+
+function luhnTest (a, b, c, d, e) {
+  for (d = +a[b = a.length - 1], e = 0; b--;) {
+    c = +a[b], d += ++e % 2 ? 2 * c % 10 + (c > 4) : c // eslint-disable-line no-sequences
+  }
+  return !(d % 10)
+}
+
+function clean (num) {
+  return num.replace(/[^0-9]+/g, '')
+}
+
+const errorMessage = 'Please enter a valid credit card number'
+
+export default {
+  errorMessage,
+  guessCard: function (num) {
+    return getLikelyMatch(clean(num))
+  },
+  cardName: function (key) {
+    return getCardType(key).name
+  },
+  validateCard: function (num, fn) {
+    var valid = validate(clean(num))
+    if (fn) { fn(valid, errorMessage) }
+    return valid
+  },
+  isValidCardType: function (type) {
+    return !!result(find(cardTypes, { key: type }), 'name')
+  },
+  maskCardInput: function (num) {
+    num = clean(num)
+    return num ? num.match(/.{1,4}/g).join('  ') : ''
+  },
+  obscureCardInput: function (num) {
+    return num.replace(/.(?=.{4})/g, 'x')
+  },
+  containsValidCard: function (text) {
+    const candidatePattern = /[0-9]{11,19}/g
+    const candidates = text.replace(/[ -]/g, '').match(candidatePattern) || []
+    return !!find(candidates, (current) => {
+      return validate(current)
+    })
+  }
+}

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,6 +1,4 @@
-/* jshint -W100 */
-
-'use strict'
+import creditCards from './creditCards'
 
 function _validate (exp, val, fn) {
   var valid = exp.test(val)
@@ -140,6 +138,13 @@ const validators = {
   phoneMessage: 'Please enter your best contact number',
   phone (val, fn) {
     return isRequired(val) && isPhone(val, fn)
+  },
+
+  absenceOfCreditCardMessage: 'Please don\'t enter a credit card number into this field',
+  absenceOfCreditCard (val, fn) {
+    const valid = !creditCards.containsValidCard(val)
+    if (fn) { fn(valid) }
+    return valid
   },
 
   custom: customValidator,


### PR DESCRIPTION
This ports the creditCard luhn check validation from supporter to HUI's validation module, so we can check for absenceOfCreditCard in HUI-driven forms (e.g. Zuul/Ray)