### PR TITLE
Port show errors from local state behaviour from Supporter

### DIFF
--- a/forms/TextInput/index.js
+++ b/forms/TextInput/index.js
@@ -63,7 +63,7 @@ export default React.createClass({
     return (
       <div className={classes}>
         <label className='hui-TextInput__label' htmlFor={inputId} ref={props.ref}>
-          { props.label }
+          {props.label}
           <input {...this.inputMethods(!props.disabled)}
             autoComplete={props.autoComplete ? 'on' : 'off'}
             className={inputClassName}
@@ -78,10 +78,10 @@ export default React.createClass({
             type={props.type}
             value={value}
             readOnly={props.readOnly} />
-          { this.renderPlaceHolder() }
-          { this.renderIcon() }
+          {this.renderPlaceHolder()}
+          {this.renderIcon()}
         </label>
-        { this.renderMessage() }
+        {this.renderMessage()}
       </div>
     )
   }

--- a/mixins/inputMessage.js
+++ b/mixins/inputMessage.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import InputErrors from '../forms/InputErrors'
 import array from 'lodash/array'
+import get from 'lodash/get'
 const { compact } = array
 
 export default {
@@ -14,15 +15,17 @@ export default {
   },
 
   shouldShowError () {
-    let errors = this.props.errors || []
+    let propErrors = this.props.errors || []
+    const stateErrors = get(this, 'state.errors') || []
+    const hasErrorArray = !!(propErrors.length || stateErrors.length)
 
-    return this.state.hasError || errors.length
+    return this.state.hasError || hasErrorArray
   },
 
   hasErrorMessages () {
     const {errorMessage, errors} = this.props
 
-    return !!this.shouldShowError() && (errors.length > 0 || !!errorMessage)
+    return this.shouldShowError() && (errors.length > 0 || !!errorMessage)
   },
 
   shouldRenderMessage () {
@@ -36,10 +39,11 @@ export default {
   },
 
   renderMessage () {
-    let props = this.props
+    const props = this.props
+    const state = this.state || {}
     let message
 
-    const displayErrors = collectErrors(this.props)
+    const displayErrors = collectErrors(props) || collectErrors(state)
 
     let errors = this.state.hasError
       ? displayErrors || compact([props.errorMessage])
@@ -53,7 +57,7 @@ export default {
 
     return this.shouldRenderMessage() && (
       <div className='hui-TextInput__message'>
-        { message }
+        {message}
       </div>
     )
   }

--- a/mixins/reactForm.mixin.js
+++ b/mixins/reactForm.mixin.js
@@ -76,7 +76,7 @@ module.exports = {
         id={'FormRow__' + name}
         key={'fieldset' + name}
         labelTop>
-        { children }
+        {children}
       </FormRow>
     )
   },

--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -44,7 +44,7 @@ export default {
 
   validate (val) {
     const { validate, required, value: propValue } = this.props
-    if (!required) { return }
+    if (!required && (!validate || !validate.length)) { return }
     let value = val || propValue || ''
 
     if (validate) {
@@ -114,7 +114,8 @@ export default {
     this.setState({
       hasError: !valid,
       waiting: false,
-      valid
+      valid,
+      errors
     })
   },
 
@@ -158,7 +159,7 @@ export default {
 
     return (
       <span className='hui-TextInput__placeHolder'>
-        { this.props.placeHolder }
+        {this.props.placeHolder}
       </span>
     )
   },


### PR DESCRIPTION
Hopefully the last piece of Supporter to come across to HUI from today. This allows inputs to collect error messages for multiple validations onto their local state, and renders them if they exist when showing validation messages.