### PR TITLE
Get the edge cases on error rendering working

### DIFF
--- a/forms/CopyInput/__tests__/CopyInput-test.js
+++ b/forms/CopyInput/__tests__/CopyInput-test.js
@@ -1,40 +1,60 @@
 'use strict'
 
+import React from 'react'
+import sinon from 'sinon'
+import { mount } from 'enzyme'
+
 import CopyInput from '../'
 
 describe('CopyInput', () => {
   let element, input, button
 
   beforeEach(() => {
-    element = renderIntoDocument(<CopyInput value='foobar' name='underTest' id='baz' />)
-    input = findByAttribute(element, 'name', 'underTest')
-    button = findByClass(element, 'hui-CopyInput__button')
+    element = mount(
+      <CopyInput
+        value='foobar'
+        name='underTest'
+        id='baz'
+        copyError='fail message'
+      />
+    )
+    input = element.find('input[name="underTest"]')
+    button = element.find('.hui-CopyInput__button')
+
+    sinon.stub(document, 'execCommand')
+  })
+
+  afterEach(() => {
+    document.execCommand.restore()
   })
 
   it('renders a text field with a given value', () => {
-    input.value.should.equal('foobar')
+    input.prop('value').should.equal('foobar')
   })
 
   it('renders copy button', () => {
-    button.tagName.should.equal('BUTTON')
+    button.is('button').should.be.true
   })
 
   it('focuses the text input when the copy button is clicked', () => {
-    Simulate.click(button)
-    document.activeElement.should.equal(input)
+    button.simulate('click')
+    const inputName = input.prop('name')
+    const activeElementName = document.activeElement.name
+    activeElementName.should.equal(inputName)
   })
 
   it('renders a default text label on the copy button', () => {
-    button.textContent.should.contain('Copy')
+    button.text().should.contain('Copy')
   })
 
   it('renders a different text label on the copy button if text has been copied', () => {
-    element.setState({ copied: true })
-    button.textContent.should.contain('Copied')
+    button.simulate('click')
+    button.text().should.contain('Copied')
   })
 
   it('shows an error message if a copy failed', () => {
-    element.setState({ errors: ['fail message'] })
-    findDOMNode(element).textContent.should.contain('fail message')
+    document.execCommand.throws('Copying disabled')
+    button.simulate('click')
+    element.text().should.contain('fail message')
   })
 })

--- a/forms/CopyInput/index.js
+++ b/forms/CopyInput/index.js
@@ -74,15 +74,18 @@ export default React.createClass({
         this.setState({ copied: false })
       }, 4000)
     } catch (error) {
-      this.setState({ errors: [this.props.copyError] })
+      this.setState({
+        hasError: true,
+        errors: [this.props.copyError]
+      })
     }
   },
 
   renderCopyButton () {
     const { labelCopy, labelCopied, labelSelect } = this.props
-    const selectBlock = <span>{ labelSelect }</span>
-    const copyBlock = <span><Icon icon='clipboard' /> { labelCopy }</span>
-    const copiedBlock = <span><Icon icon='check' /> { labelCopied }</span>
+    const selectBlock = <span>{labelSelect}</span>
+    const copyBlock = <span><Icon icon='clipboard' /> {labelCopy}</span>
+    const copiedBlock = <span><Icon icon='check' /> {labelCopied}</span>
     let content
 
     /**
@@ -102,7 +105,7 @@ export default React.createClass({
     return (
       <div className='hui-CopyInput__buttonWrapper'>
         <button className='hui-CopyInput__button' onClick={this.selectAndCopy}>
-          { content }
+          {content}
         </button>
       </div>
     )
@@ -129,7 +132,7 @@ export default React.createClass({
               onFocus={this.handleFocus}
               errors={this.state.errors} />
           </div>
-          { this.renderCopyButton() }
+          {this.renderCopyButton()}
         </div>
       </div>
     )

--- a/mixins/inputMessage.js
+++ b/mixins/inputMessage.js
@@ -19,7 +19,7 @@ export default {
     const stateErrors = get(this, 'state.errors') || []
     const hasErrorArray = !!(propErrors.length || stateErrors.length)
 
-    return this.state.hasError || hasErrorArray
+    return this.state.hasError && (hasErrorArray || this.props.errorMessage)
   },
 
   hasErrorMessages () {
@@ -49,7 +49,7 @@ export default {
       ? displayErrors || compact([props.errorMessage])
       : props.errors || []
 
-    if (errors.length > 0) {
+    if (this.state.hasError && errors.length > 0) {
       message = (<InputErrors errors={errors} />)
     } else {
       message = this.props.hint

--- a/mixins/inputMessage.js
+++ b/mixins/inputMessage.js
@@ -3,7 +3,6 @@
 import React from 'react'
 import InputErrors from '../forms/InputErrors'
 import array from 'lodash/array'
-import get from 'lodash/get'
 const { compact } = array
 
 export default {
@@ -16,16 +15,8 @@ export default {
 
   shouldShowError () {
     let propErrors = this.props.errors || []
-    const stateErrors = get(this, 'state.errors') || []
-    const hasErrorArray = !!(propErrors.length || stateErrors.length)
 
-    return this.state.hasError && (hasErrorArray || this.props.errorMessage)
-  },
-
-  hasErrorMessages () {
-    const {errorMessage, errors} = this.props
-
-    return this.shouldShowError() && (errors.length > 0 || !!errorMessage)
+    return this.state.hasError || !!propErrors.length
   },
 
   shouldRenderMessage () {
@@ -35,7 +26,7 @@ export default {
 
     const { focused } = this.state
 
-    return this.hasErrorMessages() || (!!hint && focused)
+    return this.shouldShowError() || (!!hint && focused)
   },
 
   renderMessage () {
@@ -49,7 +40,7 @@ export default {
       ? displayErrors || compact([props.errorMessage])
       : props.errors || []
 
-    if (this.state.hasError && errors.length > 0) {
+    if (this.shouldShowError()) {
       message = (<InputErrors errors={errors} />)
     } else {
       message = this.props.hint

--- a/test/helpers/testdom.js
+++ b/test/helpers/testdom.js
@@ -5,8 +5,19 @@ module.exports = function (markup, options) {
   var jsdom = require('jsdom').jsdom
   global.document = jsdom(markup || '', options)
   global.window = document.defaultView
+  global.document.execCommand = function () {}
   global.navigator = {
     userAgent: 'node.js'
   }
   // ... add whatever browser globals your tests might need ...
+  propagateToGlobal(global.window)
+}
+
+function propagateToGlobal (window) {
+  for (let key in window) {
+    if (!window.hasOwnProperty(key)) { continue }
+    if (key in global) { continue }
+
+    global[key] = window[key]
+  }
 }


### PR DESCRIPTION
Missed a couple of edge checks in the nasty nasty supporter code that prevent error messages from rendering while you're editing a field.