### PR TITLE
Ignore transpiled code when linting

### DIFF
--- a/gulp_tasks/lint.js
+++ b/gulp_tasks/lint.js
@@ -2,7 +2,7 @@ var gulp = require('gulp')
 var standard = require('gulp-standard')
 
 gulp.task('lint', function () {
-  return gulp.src(['./**/*.js', '!./node_modules/**', '!./bin/**', '!./gulp*', '!./gulp_tasks/**', '!./dist/**', '!./**/*Shim*'])
+  return gulp.src(['./**/*.js', '!./node_modules/**', '!./bin/**', '!./gulp*', '!./gulp_tasks/**', '!./dist/**', '!./transpiled/**', '!./**/*Shim*'])
     .pipe(standard())
     .pipe(standard.reporter('default', {
       breakOnError: false,


### PR DESCRIPTION
The `lint` gulp task currently spits a bunch of lint errors which clog up the console, this PR resolves that.

### State

- [x] Ready for review
- [x] Ready for merge
