### PR TITLE
Fix exception firing when option <A /> onClick handler not set

### DIFF
--- a/atoms/A/__tests__/A-test.js
+++ b/atoms/A/__tests__/A-test.js
@@ -4,10 +4,9 @@ import A from '../'
 
 describe('A', function () {
   var element
-  var fn = sinon.spy()
 
   before(function () {
-    element = TestUtils.renderIntoDocument(<A href='testurl' className='customClass' onClick={fn} />)
+    element = TestUtils.renderIntoDocument(<A href='testurl' className='customClass' />)
   })
 
   it('renders a link', function () {
@@ -22,8 +21,17 @@ describe('A', function () {
   })
 
   it('executes an onclick handler', function () {
+    var onClick = sinon.spy()
+    element = TestUtils.renderIntoDocument(<A href='testurl' className='customClass' onClick={onClick} />)
     var link = findByClass(element, 'hui-A')
-    TestUtils.Simulate.mouseUp(link)
-    fn.should.have.been.called
+    TestUtils.Simulate.click(link)
+    onClick.should.have.been.called
+  })
+
+  it.only('has a default onClick handler', function () {
+    var link = findByClass(element, 'hui-A')
+    expect(function () {
+      TestUtils.Simulate.click(link)
+    }).to.not.throw()
   })
 })

--- a/atoms/A/index.js
+++ b/atoms/A/index.js
@@ -10,9 +10,9 @@ export default React.createClass({
     onClick: React.PropTypes.func
   },
 
-  getDefaultProps: function() {
+  getDefaultProps: function () {
     return {
-      onClick: function() {} 
+      onClick: function () {}
     }
   },
 
@@ -22,7 +22,7 @@ export default React.createClass({
 
   render: function () {
     return (
-      <a href={this.props.href} className={'hui-A ' + this.props.className} onMouseUp={this.handleClick} onTouchStart={this.handleClick}>
+      <a href={this.props.href} className={'hui-A ' + this.props.className} onClick={this.handleClick}>
         { this.props.children }
       </a>
     )

--- a/atoms/A/index.js
+++ b/atoms/A/index.js
@@ -10,6 +10,12 @@ export default React.createClass({
     onClick: React.PropTypes.func
   },
 
+  getDefaultProps: function() {
+    return {
+      onClick: function() {} 
+    }
+  },
+
   handleClick: function (e) {
     this.props.onClick(e)
   },


### PR DESCRIPTION
HUI's Footer component has a bunch of <A /> components with a href but no onClick set. This is fine, but the <A /> handler has onClick as optional but always calls it, meaning you get an undefined prop exception on every Footer click.

This fixes that.