### PR TITLE
Default textInput onError prop to null making it fully opt-in

### DIFF
--- a/mixins/textInputProps.js
+++ b/mixins/textInputProps.js
@@ -97,7 +97,7 @@ export const defaults = {
   onFocus: () => {},
   onChange: () => {},
   validate: null,
-  onError: () => {},
+  onError: null,
   onBlur: () => {},
   onTab: () => {},
   onKeyDown: () => {},


### PR DESCRIPTION
So, this looks like a pretty innocuous.

In `warp-gate` we find ourselves in a position where we aren't using the `onError` callback out of the box and thus these lines give us some trouble:

https://github.com/everydayhero/hui/blob/master/mixins/textInput.js#L45-L48

```js
if (onError && validate && required) {
    const { valid, messages } = getValidator(validate)(value)
    onError(!valid, messages)
}
```

In earlier versions of HUI this has resulted in validations being run twice when we would expect them to only run once. And in the latest version of HUI we run in to errors because `getValidator` returns undefined.

I'm curious to understand if it's safe to simply not use a noop by default.

### State

- [x] Ready for review
- [x] Ready for merge


