### PR TITLE
In openPopup, support losing a reference to a closed window

### DIFF
--- a/buttons/Share/index.js
+++ b/buttons/Share/index.js
@@ -53,7 +53,8 @@ export default React.createClass({
       shareTitle: (!!document && document.title) || '',
       shareImage: '',
       action: null,
-      onClick: () => {}
+      onClick: () => {},
+      onComplete: () => {}
     }
   },
 

--- a/lib/openPopup.js
+++ b/lib/openPopup.js
@@ -23,7 +23,7 @@ function openPopup (url, config, onClose) {
   var popUp = window.open(url, 'shareWindow', config)
 
   var pollTimer = setInterval(function () {
-    if (popUp.closed !== false) {
+    if (!popUp || popUp.closed) {
       window.clearInterval(pollTimer)
       if (onClose) { onClose() }
     }


### PR DESCRIPTION
In iOS and (probably Android) browsers, we can't guarantee that the reference to the window that `window.open` creates will stick around. Users can close the tab and kill the reference, or the tab can be unloaded from memory due to low-memory devices.

This means checking `windowRef.closed` will often result in an undefined property error. This fix takes care of that.