### PR TITLE
Run validation logic only when specific prop changes are detected

### DIFF
--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -15,7 +15,7 @@ export default {
     let node = this.refs.input
     let value = node.value
     if (props.autoFocus) { node.focus() }
-    if (value && props.validate) { this.validate() }
+    if (props.validate) { this.validate() }
     this.setValue(value)
   },
 

--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { findDOMNode } from 'react-dom'
 import isArray from 'lodash/isArray'
+import isEqual from 'lodash/isEqual'
 import Icon from '../atoms/Icon'
 import classnames from 'classnames'
 import validation from '../lib/validation'
@@ -19,6 +20,22 @@ export default {
   },
 
   componentWillReceiveProps (nextProps) {
+    const nextPropsWeCareAbout = {
+      hasError: nextProps.hasError,
+      disabled: nextProps.disabled,
+      readOnly: nextProps.readOnly,
+      showError: nextProps.showError
+    }
+
+    const currentPropsWeCareAbout = {
+      hasError: this.props.hasError,
+      disabled: this.props.disabled,
+      readOnly: this.props.readOnly,
+      showError: this.props.showError
+    }
+
+    if (isEqual(nextPropsWeCareAbout, currentPropsWeCareAbout)) return
+
     let state = this.state
     if (nextProps.hasError !== undefined) {
       this.setState({hasError: nextProps.hasError})


### PR DESCRIPTION
In `warp-gate` we are seeing some pretty terrible performance due to inputs being validated every time props change. Likely because the form has quite a few inputs compared to most existing usages.

Tried doing a straight up comparison between `nextProps` and `this.props` but at any given time there are a tonne of props that we don't care about.

From what I can tell there are only a few prop changes that really matter and would warrant the subsequent logic to execute.

Also shifted initial validation to happen on mount. After some testing on the demo page a bit this surprisingly didn't change behaviour. I was worried that running validation on mount would cause errors to display immediately but they don't.

### State

- [x] Ready for review
- [x] Ready for merge

