### PR TITLE
Fix disabled input text invisible on Safari

### DIFF
--- a/sass/modules/_forms.scss
+++ b/sass/modules/_forms.scss
@@ -31,6 +31,7 @@
 }
 
 %hui-input-disabled {
+  -webkit-text-fill-color: $grey-light;
   border-bottom-color: $grey-light;
   color: $grey-light;
 }


### PR DESCRIPTION
The disabled text input area is not visible on Safari like below: 
![screen shot 2016-12-12 at 4 18 17 pm](https://cloud.githubusercontent.com/assets/3949202/21089841/22dbf770-c087-11e6-9bc5-b17e6a7086e9.png)

After the change:
![screen shot 2016-12-12 at 4 18 26 pm](https://cloud.githubusercontent.com/assets/3949202/21089844/2c85d228-c087-11e6-972d-32d67fe3e3b3.png)


### State

- [x] Ready for review
- [x] Ready for merge