### PR TITLE
Ensure address fieldset labels are regionalised

### DIFF
--- a/forms/AddressFieldset/__tests__/AddressFieldset-test.js
+++ b/forms/AddressFieldset/__tests__/AddressFieldset-test.js
@@ -24,6 +24,25 @@ describe('AddressFieldset', () => {
     expect(labels.at(4).text()).to.equal('Postcode')
   })
 
+  it('renders regionalised input labels when the region is changed', () => {
+    const wrapper = mount(<AddressFieldset />)
+    const labels = wrapper.find('.hui-TextInput__label')
+
+    expect(labels.at(0).text()).to.equal('Address')
+    expect(labels.at(1).text()).to.equal('Address 2')
+    expect(labels.at(2).text()).to.equal('Suburb')
+    expect(labels.at(3).text()).to.equal('State')
+    expect(labels.at(4).text()).to.equal('Postcode')
+
+    wrapper.setState({ countryCode: 'us' })
+
+    expect(labels.at(0).text()).to.equal('Address')
+    expect(labels.at(1).text()).to.equal('Address 2')
+    expect(labels.at(2).text()).to.equal('City')
+    expect(labels.at(3).text()).to.equal('State')
+    expect(labels.at(4).text()).to.equal('ZIP')
+  })
+
   describe('#onFieldChange()', () => {
     context('when any address value is set to something different than provided to props', () => {
       it('sets paf_validated to false', () => {

--- a/forms/AddressFieldset/i18n.js
+++ b/forms/AddressFieldset/i18n.js
@@ -11,38 +11,38 @@ export default {
     region_blank_error: 'Please enter a state',
     postal_code: 'Postcode',
     postal_code_blank_error: 'Please enter a postcode',
-    country_name: 'Country',
-    UK: {
-      locality: 'City',
-      locality_blank_error: 'Please enter a city',
-      region: 'County',
-      region_blank_error: 'Please enter a county'
-    },
-    US: {
-      locality: 'City',
-      locality_blank_error: 'Please enter a city',
-      postal_code: 'ZIP',
-      postal_code_blank_error: 'Please enter a ZIP code'
-    },
-    NZ: {
-      region: 'City',
-      region_blank_error: 'Please enter a city',
-      postal_code: 'Post Code',
-      postal_code_blank_error: 'Please enter a post code'
-    },
-    IE: {
-      region: 'County',
-      region_blank_error: 'Please enter a county',
-      postal_code: 'Postal Code',
-      postal_code_blank_error: 'Please enter a postal code'
-    },
-    CA: {
-      locality: 'City',
-      locality_blank_error: 'Please enter a city',
-      region: 'Province',
-      region_blank_error: 'Please enter a province',
-      postal_code: 'Postal Code',
-      postal_code_blank_error: 'Please enter a postal code'
-    }
+    country_name: 'Country'
+  },
+  uk: {
+    locality: 'City',
+    locality_blank_error: 'Please enter a city',
+    region: 'County',
+    region_blank_error: 'Please enter a county'
+  },
+  us: {
+    locality: 'City',
+    locality_blank_error: 'Please enter a city',
+    postal_code: 'ZIP',
+    postal_code_blank_error: 'Please enter a ZIP code'
+  },
+  nz: {
+    region: 'City',
+    region_blank_error: 'Please enter a city',
+    postal_code: 'Post Code',
+    postal_code_blank_error: 'Please enter a post code'
+  },
+  ie: {
+    region: 'County',
+    region_blank_error: 'Please enter a county',
+    postal_code: 'Postal Code',
+    postal_code_blank_error: 'Please enter a postal code'
+  },
+  ca: {
+    locality: 'City',
+    locality_blank_error: 'Please enter a city',
+    region: 'Province',
+    region_blank_error: 'Please enter a province',
+    postal_code: 'Postal Code',
+    postal_code_blank_error: 'Please enter a postal code'
   }
 }

--- a/forms/AddressFieldset/index.js
+++ b/forms/AddressFieldset/index.js
@@ -82,7 +82,7 @@ export default React.createClass({
   },
 
   fieldProps (name) {
-    const t = translate.bind(null, i18n, this.state.countryCode)
+    const t = translate.bind(null, i18n, this.state.countryCode.toLowerCase())
 
     let methods = this.props.validations[name]
     return {


### PR DESCRIPTION
Related to #429 restores functionality where switching region changes the labels.

![dec-13-2016 15-09-45](https://cloud.githubusercontent.com/assets/859298/21128506/4528fbaa-c147-11e6-8e9b-c08128ccef2d.gif)


### State

- [x] Ready for review
- [x] Ready for merge