### PR TITLE
Prefix field refs to avoid onFocus bugs

### DIFF
--- a/forms/AddressFieldset/index.js
+++ b/forms/AddressFieldset/index.js
@@ -87,7 +87,7 @@ export default React.createClass({
     let methods = this.props.validations[name]
     return {
       ...this.fieldMethods(name),
-      ref: name,
+      ref: this.props.prefix + name,
       key: name,
       name: this.props.prefix + name,
       label: t(name),


### PR DESCRIPTION
When multiple `AddressFieldset` components appear on the page together the refs can sometimes clash. This currently causes problems in Safari browser.

### State

- [x] Ready for review
- [x] Ready for merge