### PR TITLE
Respect show error

### DIFF
--- a/mixins/__tests__/inputMessage-test.js
+++ b/mixins/__tests__/inputMessage-test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import inputMessage from '../inputMessage'
+
+const MockComponent = React.createClass({
+  mixins: [inputMessage],
+  render () {
+    return <div>foo</div>
+  }
+})
+
+describe('inputMessage', () => {
+  it('only shows errors if the showError prop is true', () => {
+    const wrapper = shallow(<MockComponent showError={false} />)
+    wrapper.setState({ hasError: true })
+
+    expect(wrapper.instance().shouldShowError()).to.equal(false)
+    wrapper.setProps({ errors: ['foo', 'bar'] })
+    expect(wrapper.instance().shouldShowError()).to.equal(false)
+    wrapper.setProps({ showError: true })
+    expect(wrapper.instance().shouldShowError()).to.equal(true)
+  })
+})

--- a/mixins/inputMessage.js
+++ b/mixins/inputMessage.js
@@ -17,7 +17,7 @@ export default {
     const { errors, showError } = this.props
     const propErrors = errors || []
 
-    return this.state.hasError || (showError && !!propErrors.length)
+    return (showError && this.state.hasError) || (showError && !!propErrors.length)
   },
 
   shouldRenderMessage () {

--- a/mixins/textInput.js
+++ b/mixins/textInput.js
@@ -59,9 +59,9 @@ export default {
     let { onChange, onError, validate, required } = props
 
     if (onChange) { onChange(value) }
-    if (onError && validate && required) {
-      const { valid, messages } = getValidator(validate)(value)
-      onError(!valid, messages)
+    if (validate && required) {
+      const validation = getValidator(validate)(value)
+      onError && onError(!validation.valid, validation.messages)
     }
   },
 


### PR DESCRIPTION
Again a little anxious in this area given the lack of tests. But to me it makes sense that if the showError prop is set to `false` then we should respect that at all times and suppress the error.

### State

- [x] Ready for review
- [x] Ready for merge
