### PR TITLE
Fix filepicker mimetypes option clashing (v4)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -94,6 +94,7 @@
     "before": 1,
     "beforeEach": 1,
     "after": 1,
+    "afterEach": 1,
     "it": 1,
     "xit": 1,
     "React": 1,

--- a/DemoPage/__tests__/DemoPage-test.js
+++ b/DemoPage/__tests__/DemoPage-test.js
@@ -1,18 +1,12 @@
 'use strict';
 
+import { shallow } from 'enzyme'
 import Page from '../'
 
 describe('Demo Page', function() {
-  describe('default', function() {
-    var page;
-
-    beforeEach(function() {
-      page = renderIntoDocument(Page)
-    });
-
-    it('should render Page', function() {
-      page.should.exist;
-    });
+  it('should render Page', function() {
+    var page = shallow(Page)
+    page.should.exist;
   });
 });
 

--- a/forms/FileInput/__tests__/FileInput-test.js
+++ b/forms/FileInput/__tests__/FileInput-test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import FileInput from '../'
+import filepicker from '../../../lib/filepicker'
 
 describe('FileInput', function() {
   var noFileLabel = 'No file selected';
@@ -60,4 +61,43 @@ describe('FileInput', function() {
       errors.textContent.should.contain('is not good');
     });
   });
+
+  describe('mimetype options', function () {
+    beforeEach(function () {
+      sinon.stub(filepicker, 'pick')
+    })
+
+    afterEach(function () {
+      filepicker.pick.restore()
+    })
+
+    it('sets a default mimetypes option', function () {
+      Simulate.click(findByClass(component, 'hui-FileInput__browse'))
+      expect(filepicker.pick.args[0][0].mimetypes).to.contain('image/*')
+    })
+
+    it('does not set a mimetypes option if extension option is present', function () {
+      component = renderIntoDocument(
+        <FileInput
+          noFileLabel={noFileLabel}
+          options={{ extension: '.jpg' }} />
+      )
+
+      Simulate.click(findByClass(component, 'hui-FileInput__browse'))
+      expect(filepicker.pick.args[0][0].extension).to.equal('.jpg')
+      expect(filepicker.pick.args[0][0].mimetypes).to.be.undefined
+    })
+
+    it('does not set a mimetypes option if extensions option is present', function () {
+      component = renderIntoDocument(
+        <FileInput
+          noFileLabel={noFileLabel}
+          options={{ extensions: ['.jpg', '.png'] }} />
+      )
+
+      Simulate.click(findByClass(component, 'hui-FileInput__browse'))
+      expect(filepicker.pick.args[0][0].extensions).to.eql(['.jpg', '.png'])
+      expect(filepicker.pick.args[0][0].mimetypes).to.be.undefined
+    })
+  })
 });

--- a/forms/FileInput/index.js
+++ b/forms/FileInput/index.js
@@ -52,7 +52,10 @@ export default React.createClass({
     var props = this.props
     var options = props.options
 
-    options.mimetypes = options.mimetypes || props.mimetypes
+    if (!options.extension && !options.extensions) {
+      options.mimetypes = options.mimetypes || props.mimetypes
+    }
+
     options.services = options.services || props.services
 
     e.preventDefault()


### PR DESCRIPTION
Using the built in `extension` and `extensions` options with `FileInput` currently causes an error as it is incompatible with the `mimetypes` option.

From the filepicker docs regarding extension options:

> Specify the type of file that the user is allowed to pick by extension. *Do not use this option with mimetype(s) specified as well*.

https://www.filepicker.com/docs/file-ingestion/javascript-api/pick?v=v2

This PR resolves that error by only setting the `mimetypes` option if the `extension` or `extensions` are not defined.

### State

- [x] Ready for review
- [x] Ready for merge

### Notes

I will duplicate this work over on the master v5 branch shortly.