### PR TITLE
Fix issue with FilterSelect labels that span multiple lines

### DIFF
--- a/forms/FilterSelect/Display/style.scss
+++ b/forms/FilterSelect/Display/style.scss
@@ -7,7 +7,10 @@
 .hui-FilterSelectDisplay__wrap {
   @extend %hui-input-border;
   position: relative;
+  height: auto;
+  min-height: 42px;
   padding-right: 25px;
+  padding-bottom: $x-7;
 }
 
 .hui-FilterSelectDisplay__label {
@@ -23,7 +26,7 @@
 
 .hui-FilterSelectDisplay__value {
   position: absolute;
-  top: 9px;
+  bottom: 3px;
   left: 0px;
   color: $grey;
   letter-spacing: 0.10em;

--- a/sass/modules/_forms.scss
+++ b/sass/modules/_forms.scss
@@ -21,7 +21,7 @@
   text-transform: uppercase;
   letter-spacing: 0.16em;
   font-size: 9px;
-  line-height: 9px;
+  line-height: 12px;
   color: $grey;
   position: relative;
   display: block;


### PR DESCRIPTION
If a label spanned 2 lines, which is reasonable on smaller viewports,
there was a few problems...

1) the line height on the label meant the lines were way too close
2) no extra space was left to show the selected value, which meant it
often displayed underneath the label

**Before**

![image](https://user-images.githubusercontent.com/1445686/34921287-c7e06048-f9cb-11e7-909d-5b1c517a88d9.png)

**After**

![image](https://user-images.githubusercontent.com/1445686/34921294-d3e09584-f9cb-11e7-9d9b-94220255ed2d.png)

### State

- [x] Ready for review
- [x] Ready for merge

### Pre-merge Tasks

Tasks to be actioned by the author of this pull request **BEFORE** it is merged.

None

### Post-merge Tasks

Tasks to be actioned by the author of this pull request **AFTER** it is merged.

None

### Testing Notes

I just ran the docs locally, and tested the FilterSelect component with labels of various length.

### Related Jira ticket or GitHub issue numbers

https://edhdev.atlassian.net/browse/PS-3698

### Notes

This issue has been reported by a couple of clients who are using groups, and due to the layout of the one page get started form, the form fields aren't very wide, and many group value questions can span a second line.

## Release Notes

No change to any form field elements, except for anywhere the FilterSelect component is used, and the label takes up multiple lines.
