### PR TITLE
Allow compound text and dropdown inputs

### DIFF
--- a/DemoPage/examples/TextInput/index.js
+++ b/DemoPage/examples/TextInput/index.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import TextCountDownInput from '../../../forms/TextCountDownInput'
 import TextInput from '../../../forms/TextInput'
+import SimpleSelectInput from '../../../forms/SimpleSelectInput'
 import formMixin from '../../../mixins/reactForm.mixin'
 
 export default React.createClass({
@@ -90,6 +91,29 @@ export default React.createClass({
           max={20}
           warnMax={10}
           onChange={change('demo_input_07')} />
+
+        <TextInput
+          id='demo_input_attached_dropdown'
+          name='demo_input_attached_dropdown'
+          value={this.state.form.demo_input_08}
+          label='custom input with child input'
+          childPosition='right'
+          onChange={change('demo_input_08')}
+        >
+          <SimpleSelectInput
+            labelKey='label'
+            valueKey='value'
+            layout='compact'
+            spacing='compact'
+            value={this.state.form.demo_input_09}
+            onChange={change('demo_input_09')}
+            options={[
+              {label: 'Steps', value: 'steps'},
+              {label: 'Miles', value: 'miles'},
+              {label: 'Kms', value: 'kilometers'}
+            ]}
+          />
+        </TextInput>
       </div>
     )
   }

--- a/assets.scss
+++ b/assets.scss
@@ -58,6 +58,7 @@
 @import "forms/FormRow/style";
 @import "forms/ImageInput/style";
 @import "forms/SelectInput/style";
+@import "forms/SimpleSelectInput/style";
 @import "forms/SearchInput/style";
 @import "forms/TagList/style";
 @import "forms/TagList/Item/style";

--- a/forms/SimpleSelectInput/index.js
+++ b/forms/SimpleSelectInput/index.js
@@ -1,0 +1,228 @@
+'use strict'
+
+import _ from 'lodash'
+import React from 'react'
+import Icon from '../../atoms/Icon'
+import LocalStorageMixin from '../../mixins/localStorage'
+import classnames from 'classnames'
+
+/**
+This is a 'simple' select, meant to be attached to the right
+of an existing field to add, say, a unit drop down for a number
+field.
+*/
+
+export default React.createClass({
+  displayName: 'SimpleSelectInput',
+
+  mixins: [LocalStorageMixin],
+
+  propTypes: {
+    autoComplete: React.PropTypes.bool,
+    storeLocally: React.PropTypes.bool,
+    autoFocus: React.PropTypes.bool,
+    disabled: React.PropTypes.bool,
+    name: React.PropTypes.string,
+    hint: React.PropTypes.string,
+    onFocus: React.PropTypes.func,
+    onChange: React.PropTypes.func,
+    onBlur: React.PropTypes.func,
+    includeBlank: React.PropTypes.bool,
+    onTab: React.PropTypes.func,
+    required: React.PropTypes.bool,
+    spacing: React.PropTypes.string,
+    layout: React.PropTypes.string,
+    options: React.PropTypes.array,
+    prompt: React.PropTypes.string,
+    value: React.PropTypes.string,
+    labelKey: React.PropTypes.string,
+    valueKey: React.PropTypes.string,
+    errors: React.PropTypes.array,
+    label: React.PropTypes.node,
+    errorMessage: React.PropTypes.node
+  },
+
+  getDefaultProps: function () {
+    return {
+      autoComplete: true,
+      storeLocally: false,
+      autoFocus: false,
+      disabled: false,
+      name: null,
+      hint: '',
+      onFocus: null,
+      onChange: null,
+      onBlur: function () {},
+      includeBlank: false,
+      onTab: function () {},
+      required: false,
+      spacing: 'loose',
+      layout: 'full',
+      options: [],
+      prompt: null,
+      value: null,
+      labelKey: 'label',
+      valueKey: 'value',
+      errors: [],
+      label: 'Select',
+      errorMessage: null
+    }
+  },
+
+  getInitialState: function () {
+    return {
+      focused: false
+    }
+  },
+
+  componentDidMount: function () {
+    var props = this.props
+
+    if (props.disabled) { return }
+    if (props.autoFocus) { this.refs.input.focus() }
+  },
+
+  onChange: function (event) {
+    var onChange = this.props.onChange
+    var value = event.target.value
+    var hasError = this.props.required ? !value : false
+
+    this.setState({
+      value,
+      hasError
+    })
+
+    if (onChange) {
+      onChange(value)
+    }
+  },
+
+  onBlur: function () {
+    var props = this.props
+    var hasError = props.required ? !props.value : false
+
+    if (props.onBlur) { props.onBlur(props.value) }
+    this.setState({ focused: false, hasError })
+  },
+
+  onFocus: function () {
+    var props = this.props
+    if (props.onFocus) { props.onFocus(props.value) }
+    this.setState({ focused: true, valid: true })
+  },
+
+  getSelected: function () {
+    var options = this.getOptions()
+    var props = this.props
+    var criteria = {}
+
+    if (props.value) {
+      criteria[props.valueKey] = props.value
+
+      return _.filter(options, criteria)[0]
+    }
+  },
+
+  getOptions: function () {
+    var props = this.props
+    var options = props.options.slice()
+    var blank = {}
+
+    if (props.includeBlank) {
+      blank[props.valueKey] = ''
+      blank[props.labelKey] = ''
+      options.unshift(blank)
+    }
+
+    return options
+  },
+
+  renderDisplayValue: function () {
+    var props = this.props
+    var value = props.value
+    var className = 'hui-SimpleSelectInput__selected'
+    var displayValue = props.prompt
+    var selectedOption = this.getSelected()
+    var firstOption = this.getOptions()[0]
+    var firstLabel = firstOption && firstOption[props.labelKey]
+
+    if (!value && !firstLabel && !this.props.selectionMade) {
+      className += '--noSelection'
+    }
+
+    if (selectedOption) {
+      displayValue = selectedOption[props.labelKey]
+    } else if (firstLabel) {
+      displayValue = firstLabel
+    }
+
+    return (
+      <div className='hui-SimpleSelectInput__displayValue'>
+        <div className={className}>
+          {displayValue}
+        </div>
+      </div>
+    )
+  },
+
+  renderOptions: function () {
+    var props = this.props
+    var valueKey = props.valueKey
+    var labelKey = props.labelKey
+    var options = this.getOptions()
+
+    return _.map(options, function (option, index) {
+      var optionValue = option[valueKey]
+
+      return (
+        <option
+          key={index}
+          label={option[labelKey]}
+          value={optionValue} >
+          {option[labelKey]}
+        </option>
+        )
+    })
+  },
+
+  render: function () {
+    var props = this.props
+    var state = this.state
+    var value = props.value
+    var layout = props.layout
+    var spacing = props.spacing
+    var classes = classnames([
+      'hui-SimpleSelectInput--' + layout,
+      'hui-SimpleSelectInput--' + spacing,
+      'hui-SimpleSelectInput',
+      !!value && 'hui-SimpleSelectInput--hasValue',
+      state.focused && 'hui-SimpleSelectInput--focused',
+      state.valid && 'hui-SimpleSelectInput--valid',
+      props.disabled && 'hui-SimpleSelectInput--disabled'
+    ])
+
+    return (
+      <div className={classes}>
+        <div className='hui-SimpleSelectInput__wrap'>
+          {this.renderDisplayValue()}
+          <Icon icon='chevron-down' className='hui-SimpleSelectInput__icon' />
+          <div className='hui-SimpleSelectInput__inputWrap'>
+            <select
+              autoComplete={props.autoComplete}
+              className='hui-SimpleSelectInput__input'
+              id={props.id || props.name}
+              disabled={props.disabled}
+              name={props.name || props.id}
+              onBlur={this.onBlur}
+              onFocus={this.onFocus}
+              onChange={this.onChange}
+              onKeyDown={this.onTab}
+              value={value}>
+              {this.renderOptions()}
+            </select>
+          </div>
+        </div>
+      </div>
+    )
+  }
+})

--- a/forms/SimpleSelectInput/style.scss
+++ b/forms/SimpleSelectInput/style.scss
@@ -1,0 +1,84 @@
+@import "../InputErrors/style";
+
+.hui-SimpleSelectInput {
+  @extend %hui-input-base;
+}
+
+.hui-SimpleSelectInput__wrap {
+  @extend %hui-input-border;
+  border-left: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.hui-SimpleSelectInput__label {
+  @extend %hui-input-label;
+}
+
+.hui-SimpleSelectInput__displayValue {
+  background-image: none;
+  width: 100%;
+  height: 100%;
+  font-size: 15px;
+}
+
+.hui-SimpleSelectInput__selected,
+.hui-SimpleSelectInput__selected--noSelection {
+  color: $grey;
+  letter-spacing: 0.10em;
+  line-height: $x-9 - 1;
+  pointer-events:none;
+  padding-right: $x-7;
+}
+
+.hui-SimpleSelectInput__selected--noSelection {
+  color: $grey-light;
+}
+
+.hui-SimpleSelectInput__inputWrap {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 42px;
+}
+
+.hui-SimpleSelectInput__input {
+  background-image: none;
+  opacity: 0;
+  width: 100%;
+  min-height: 42px;
+  position: relative;
+  top: 0px;
+  left: 0px;
+}
+
+.hui-SimpleSelectInput__icon {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.hui-SimpleSelectInput--disabled .hui-SimpleSelectInput__wrap,
+.hui-SimpleSelectInput--disabled .hui-SimpleSelectInput__selected,
+.hui-SimpleSelectInput--disabled .hui-SimpleSelectInput__label {
+  @extend %hui-input-disabled;
+}
+
+.hui-SimpleSelectInput--focused .hui-SimpleSelectInput__wrap,
+.hui-SimpleSelectInput--focused .hui-SimpleSelectInput__label {
+  @extend %hui-input-focused;
+}
+
+.hui-SimpleSelectInput--error .hui-TextInput__message {
+  @extend %error-message;
+}
+
+.hui-SimpleSelectInput--error .hui-SimpleSelectInput__icon,
+.hui-SimpleSelectInput--error .hui-SimpleSelectInput__wrap,
+.hui-SimpleSelectInput--error .hui-SimpleSelectInput__label {
+  @extend %hui-input-error;
+}
+
+@include input-sizes(SimpleSelectInput);

--- a/forms/TextInput/index.js
+++ b/forms/TextInput/index.js
@@ -12,10 +12,16 @@ export default React.createClass({
 
   mixins: [LocalStorageMixin, inputMessage, textInput],
 
-  propTypes: types,
+  propTypes: {
+    ...types,
+    attachedInput: React.PropTypes.node
+  },
 
   getDefaultProps () {
-    return defaults
+    return {
+      ...defaults,
+      childPosition: 'right'
+    }
   },
 
   getInitialState () {
@@ -60,27 +66,48 @@ export default React.createClass({
     })
     let inputId = props.id || props.name
 
+    let labelClassName = classnames({
+      'hui-TextInput__label': true,
+      'hui-TextInput__label__with-child': props.children
+    })
+    let groupClassName = classnames({
+      'hui-TextInput__with-child': props.children
+    })
+    let childClassName = classnames({
+      'hui-ChildInput': true
+    })
+
     return (
       <div className={classes}>
-        <label className='hui-TextInput__label' htmlFor={inputId} ref={props.ref}>
-          {props.label}
-          <input {...this.inputMethods(!props.disabled)}
-            autoComplete={props.autoComplete ? 'on' : 'off'}
-            className={inputClassName}
-            disabled={props.disabled}
-            id={inputId}
-            name={props.name}
-            ref='input'
-            onKeyDown={(e) => {
-              this.onTab(e)
-              this.props.onKeyDown(e)
-            }}
-            type={props.type}
-            value={value}
-            readOnly={props.readOnly} />
-          {this.renderPlaceHolder()}
-          {this.renderIcon()}
-        </label>
+        <div className={groupClassName}>
+          <label className={labelClassName} htmlFor={inputId} ref={props.ref}>
+            {props.label}
+
+            <input {...this.inputMethods(!props.disabled)}
+              autoComplete={props.autoComplete ? 'on' : 'off'}
+              className={inputClassName}
+              disabled={props.disabled}
+              id={inputId}
+              name={props.name}
+              ref='input'
+              onKeyDown={(e) => {
+                this.onTab(e)
+                this.props.onKeyDown(e)
+              }}
+              type={props.type}
+              value={value}
+              readOnly={props.readOnly} />
+
+            {this.renderPlaceHolder()}
+            {this.renderIcon()}
+          </label>
+
+          {props.children &&
+            <div className={childClassName}>
+              {props.children}
+            </div>
+          }
+        </div>
         {this.renderMessage()}
       </div>
     )

--- a/forms/TextInput/style.scss
+++ b/forms/TextInput/style.scss
@@ -10,6 +10,11 @@
   z-index: 1;
 }
 
+.hui-TextInput__label__with-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .hui-TextInput__input {
   font-family: $font-copy;
   display: block;
@@ -108,6 +113,10 @@
 
 .hui-TextInput--focused .hui-TextInput__message {
   @extend %hui-input-focused;
+}
+
+.hui-TextInput__with-child {
+  display: flex;
 }
 
 @include input-sizes(TextInput);


### PR DESCRIPTION
This is some garbage code. HUI's styles are basically un-enhanceable, so the best course of action for 'do something in HUI that is similar but not quite the same as existing inputs' is to copy/paste and modify the new component.

I need this new SimpleSelectInput component as a child of TextInput for the new manual fitness UI refit.

Generates the below component:

<img width="798" alt="screen shot 2018-02-01 at 3 21 58 pm" src="https://user-images.githubusercontent.com/148739/35662401-ae754e3e-0763-11e8-8be2-64444dbe6f79.png">
