### PR TITLE
Scope blurring timer in FocusAggregate per instance

### DIFF
--- a/forms/FocusAggregate/index.js
+++ b/forms/FocusAggregate/index.js
@@ -1,8 +1,4 @@
-'use strict'
-
 import React from 'react'
-
-var blurringTimer
 
 export default React.createClass({
   displayName: 'FocusAggregate',
@@ -13,15 +9,15 @@ export default React.createClass({
     }
   },
   componentWillUnmount () {
-    clearTimeout(blurringTimer)
+    clearTimeout(this.blurringTimer)
   },
   handleFocus (e) {
-    clearTimeout(blurringTimer)
+    clearTimeout(this.blurringTimer)
     this.props.onFocus(e)
   },
   handleBlur (e) {
-    clearTimeout(blurringTimer)
-    blurringTimer = setTimeout(() => {
+    clearTimeout(this.blurringTimer)
+    this.blurringTimer = setTimeout(() => {
       this.props.onBlur(e)
     })
   },


### PR DESCRIPTION
I'm not able to recreate them, but we have a few errors in sentry that
_might_ be related to methods being called on objects which have been
"cleaned up" ready for reuse. I don't know if this is something react
does. The idea is to try and make this a little more reasonable (it's
not totally reasonable because the job it's doing is pretty weird). I
doubt this will have any effect of on those errors ... but if it does:
super.

### State

- [x] Ready for review
- [x] Ready for merge

### Post-merge Tasks

Tasks to be actioned by the author of this pull request **AFTER** it is merged.

- [ ] Cut a patch release.

### Notes

The job of the FocusAggregate is to call it's onBlur handler only once in the case of a stream of `blur, focus, blur` events. Why? Because this way we get a blur event when hovering over or keyboard nav-ing through a list of radio buttons (the OptionList). Why do we care about focus? Because we can't capture keyboard events at the component level without an input which has focus. After using radio buttons to capture focus when keyboard nav-ing through the OptionList we could also use the blur events to close the list. This gave us a way to handle clicking outside an element without installing global event handlers. In hindsight avoiding custom selects might have been a good way to go, or having an interface that didn't try to insert / remove these drop-downs but rather left them open ... better luck next time as they say.
