### PR TITLE
Remove isGoogleLookup and branding from AddressLookup list.

### DIFF
--- a/forms/AddressLookup/index.js
+++ b/forms/AddressLookup/index.js
@@ -78,10 +78,6 @@ export default React.createClass({
         this.state.selectedCountry.value) === 'UK')
   },
 
-  isGoogleLookup () {
-    return !this.isPAFLookup()
-  },
-
   removeNull (o) {
     return forEach(o, (d, k) => { o[k] = d === null ? '' : d })
   },
@@ -142,7 +138,6 @@ export default React.createClass({
     ])
     let urlSearchSelectClasses = classnames({
       'hui-AddressLookup_url-search-select': true,
-      'hui-AddressLookup_url-search-select--google': this.isGoogleLookup(),
       'hui-AddressLookup_url-search-select--inactive': state.isSelectingCountry
     })
     let countrySelectClasses = classnames({

--- a/forms/AddressLookup/style.scss
+++ b/forms/AddressLookup/style.scss
@@ -50,22 +50,3 @@
 .hui-AddressLookup_url-search-select .hui-TextInput__icon {
   right: 90 + $x-2;
 }
-
-.hui-AddressLookup_url-search-select--google .hui-UrlSearchSelect__dropdown:after {
-  content: "";
-  background-image: url(../images/powered_by_google_on_white.png);
-  background-image: url(../images/powered_by_google_on_white.svg);
-  background-position: 50% 50%;
-  background-size: contain;
-  background-repeat: no-repeat;
-  width: 108px;
-  height: 15px;
-  float: right;
-  margin: 8px;
-  display: block;
-  font-size: 0;
-}
-
-.hui-AddressLookup_url-search-select--google .hui-UrlSearchSelect__manual-action {
-  padding-bottom: 0;
-}


### PR DESCRIPTION
We're no longer using Google for address lookup, because they're now really expensive. We're now using only Loqate (used to be Postcode Anywhere, same company) in every region. This means the "Powered by Google" branding required in non-UK regions is no longer required.